### PR TITLE
fix Pixelate filter

### DIFF
--- a/src/pixelate/PixelateFilter.js
+++ b/src/pixelate/PixelateFilter.js
@@ -40,7 +40,7 @@ Object.defineProperties(PixelateFilter.prototype, {
         },
         set: function (value)
         {
-            this.uniforms.size.value = value;
+            this.uniforms.size = value;
         }
     }
 });


### PR DESCRIPTION
this change fixes `PixelateFilter` in the example app.

as it turned out, the filter is fixed by simply assigning the new value to `uniforms.size` instead of `uniforms.size.value`.

I'm sad to admit that I don't yet know enough about pixi.js to describe why this works or why the previous implementation was broken.
