### PR TITLE
Better PIXI Namespace Definitions

### DIFF
--- a/filters/ascii/src/AsciiFilter.js
+++ b/filters/ascii/src/AsciiFilter.js
@@ -35,3 +35,6 @@ export default class AsciiFilter extends PIXI.Filter {
         this.uniforms.pixelSize = value;
     }
 }
+
+// Export to PixiJS namespace
+PIXI.filters.AsciiFilter = AsciiFilter;

--- a/filters/bloom/src/BloomFilter.js
+++ b/filters/bloom/src/BloomFilter.js
@@ -78,3 +78,7 @@ export default class BloomFilter extends PIXI.Filter {
         this.blurYFilter.blur = value;
     }
 }
+
+// Export to PixiJS namespace
+PIXI.filters.BloomFilter = BloomFilter;
+

--- a/filters/bulge-pinch/src/BulgePinchFilter.js
+++ b/filters/bulge-pinch/src/BulgePinchFilter.js
@@ -67,3 +67,7 @@ export default class BulgePinchFilter extends PIXI.Filter {
         this.uniforms.center = value;
     }
 }
+
+// Export to PixiJS namespace
+PIXI.filters.BulgePinchFilter = BulgePinchFilter;
+

--- a/filters/color-replace/src/ColorReplaceFilter.js
+++ b/filters/color-replace/src/ColorReplaceFilter.js
@@ -94,3 +94,7 @@ export default class ColorReplaceFilter extends PIXI.Filter {
         return this.uniforms.epsilon;
     }
 }
+
+// Export to PixiJS namespace
+PIXI.filters.ColorReplaceFilter = ColorReplaceFilter;
+

--- a/filters/convolution/src/ConvolutionFilter.js
+++ b/filters/convolution/src/ConvolutionFilter.js
@@ -60,3 +60,7 @@ export default class ConvolutionFilter extends PIXI.Filter {
         this.uniforms.texelSize[1] = 1/value;
     }
 }
+
+// Export to PixiJS namespace
+PIXI.filters.ConvolutionFilter = ConvolutionFilter;
+

--- a/filters/cross-hatch/src/CrossHatchFilter.js
+++ b/filters/cross-hatch/src/CrossHatchFilter.js
@@ -13,3 +13,6 @@ export default class CrossHatchFilter extends PIXI.Filter {
         super(vertex, fragment);
     }
 }
+
+// Export to PixiJS namespace
+PIXI.filters.CrossHatchFilter = CrossHatchFilter;

--- a/filters/dot/src/DotFilter.js
+++ b/filters/dot/src/DotFilter.js
@@ -48,3 +48,6 @@ export default class DotFilter extends PIXI.Filter {
         this.uniforms.angle = value;
     }
 }
+
+// Export to PixiJS namespace
+PIXI.filters.DotFilter = DotFilter;

--- a/filters/drop-shadow/src/DropShadowFilter.js
+++ b/filters/drop-shadow/src/DropShadowFilter.js
@@ -108,3 +108,6 @@ export default class DropShadowFilter extends PIXI.Filter {
     }
 }
 
+// Export to PixiJS namespace
+PIXI.filters.DropShadowFilter = DropShadowFilter;
+

--- a/filters/emboss/src/EmbossFilter.js
+++ b/filters/emboss/src/EmbossFilter.js
@@ -27,3 +27,6 @@ export default class EmbossFilter extends PIXI.Filter {
         this.uniforms.strength = value;
     }
 }
+
+// Export to PixiJS namespace
+PIXI.filters.EmbossFilter = EmbossFilter;

--- a/filters/glow/src/GlowFilter.js
+++ b/filters/glow/src/GlowFilter.js
@@ -83,3 +83,6 @@ export default class GlowFilter extends PIXI.Filter {
         this.uniforms.innerStrength = value;
     }
 }
+
+// Export to PixiJS namespace
+PIXI.filters.GlowFilter = GlowFilter;

--- a/filters/outline/src/OutlineFilter.js
+++ b/filters/outline/src/OutlineFilter.js
@@ -48,3 +48,7 @@ export default class OutlineFilter extends PIXI.Filter {
         this.uniforms.thickness = value;
     }
 }
+
+// Export to PixiJS namespace
+PIXI.filters.OutlineFilter = OutlineFilter;
+

--- a/filters/pixelate/src/PixelateFilter.js
+++ b/filters/pixelate/src/PixelateFilter.js
@@ -33,3 +33,6 @@ export default class PixelateFilter extends PIXI.Filter {
         this.uniforms.size = value;
     }
 }
+
+// Export to PixiJS namespace
+PIXI.filters.PixelateFilter = PixelateFilter;

--- a/filters/rgb-split/src/RGBSplitFilter.js
+++ b/filters/rgb-split/src/RGBSplitFilter.js
@@ -55,3 +55,6 @@ export default class RGBSplitFilter extends PIXI.Filter {
         this.uniforms.blue = value;
     }
 }
+
+// Export to PixiJS namespace
+PIXI.filters.RGBSplitFilter = RGBSplitFilter;

--- a/filters/shockwave/src/ShockwaveFilter.js
+++ b/filters/shockwave/src/ShockwaveFilter.js
@@ -73,3 +73,7 @@ export default class ShockwaveFilter extends PIXI.Filter {
         this.uniforms.time = value;
     }
 }
+
+// Export to PixiJS namespace
+PIXI.filters.ShockwaveFilter = ShockwaveFilter;
+

--- a/filters/simple-lightmap/src/SimpleLightmapFilter.js
+++ b/filters/simple-lightmap/src/SimpleLightmapFilter.js
@@ -65,3 +65,7 @@ export default class SimpleLightmapFilter extends PIXI.Filter {
         this.uniforms.resolution = new Float32Array(value);
     }
 }
+
+// Export to PixiJS namespace
+PIXI.filters.SimpleLightmapFilter = SimpleLightmapFilter;
+

--- a/filters/tilt-shift/src/TiltShiftAxisFilter.js
+++ b/filters/tilt-shift/src/TiltShiftAxisFilter.js
@@ -91,3 +91,7 @@ export default class TiltShiftAxisFilter extends PIXI.Filter {
         this.updateDelta();
     }
 }
+
+// Export to PixiJS namespace
+PIXI.filters.TiltShiftAxisFilter = TiltShiftAxisFilter;
+

--- a/filters/tilt-shift/src/TiltShiftFilter.js
+++ b/filters/tilt-shift/src/TiltShiftFilter.js
@@ -80,3 +80,6 @@ export default class TiltShiftFilter extends PIXI.Filter {
         this.tiltShiftXFilter.end = this.tiltShiftYFilter.end = value;
     }
 }
+
+// Export to PixiJS namespace
+PIXI.filters.TiltShiftFilter = TiltShiftFilter;

--- a/filters/tilt-shift/src/TiltShiftXFilter.js
+++ b/filters/tilt-shift/src/TiltShiftXFilter.js
@@ -25,3 +25,6 @@ export default class TiltShiftXFilter extends TiltShiftAxisFilter {
         this.uniforms.delta.y = dy / d;
     }
 }
+
+// Export to PixiJS namespace
+PIXI.filters.TiltShiftXFilter = TiltShiftXFilter;

--- a/filters/tilt-shift/src/TiltShiftYFilter.js
+++ b/filters/tilt-shift/src/TiltShiftYFilter.js
@@ -25,3 +25,6 @@ export default class TiltShiftYFilter extends TiltShiftAxisFilter {
         this.uniforms.delta.y = dx / d;
     }
 }
+
+// Export to PixiJS namespace
+PIXI.filters.TiltShiftYFilter = TiltShiftYFilter;

--- a/filters/twist/src/TwistFilter.js
+++ b/filters/twist/src/TwistFilter.js
@@ -56,3 +56,6 @@ export default class TwistFilter extends PIXI.Filter {
         this.uniforms.angle = value;
     }
 }
+
+// Export to PixiJS namespace
+PIXI.filters.TwistFilter = TwistFilter;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lerna": "lerna"
   },
   "devDependencies": {
+    "eslint": "^4.6.1",
     "gh-pages": "^0.11.0",
     "http-server": "^0.9.0",
     "jaguarjs-jsdoc": "^1.0.0",

--- a/tools/build/index.js
+++ b/tools/build/index.js
@@ -67,12 +67,9 @@ const banner = `/*!
 const moduleName = `__${name.replace(/-/g, '_')}`;
 
 let intro = '';
-let outro = '';
 
-// UMD use module name
-if (format !== 'es') {
-    intro =`if (typeof PIXI.Filter === 'undefined') { throw 'PixiJS is required'; }`;
-    outro = `Object.assign(PIXI.filters, exports);`;
+if (!prod) {
+    intro = `if (typeof PIXI === 'undefined' || typeof PIXI.filters === 'undefined') { throw 'PixiJS is required'; }`;
 }
 
 module.exports = {
@@ -80,7 +77,6 @@ module.exports = {
     format,
     moduleName,
     intro,
-    outro,
     entry,
     dest,
     sourceMap: true,


### PR DESCRIPTION
Fixes #32 

The **es** build now includes setting the `PIXI` namespace for filters. Previously, only the **umd** supported this.