### PR TITLE
Housekeeping Fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
   - "6"
 
 install:
-  - npm run bootstrap
+  - npm install
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ npm install pixi-filters
 
 ## Building
 
-PixiJS Filter uses [Lerna](https://github.com/lerna/lerna) to build all of the filter separately. Install all dependencies by running the following. Note, it's not required to `npm install`.
+PixiJS Filters uses [Lerna](https://github.com/lerna/lerna) under-the-hood to build all of the filters separately. Install all dependencies by simply running the following.
 
 ```bash
-npm run bootstrap
+npm install
 ```
 
 Build all filters by running the following:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "prebootstrap": "npm install",
+    "postinstall": "npm run bootstrap",
     "bootstrap": "lerna bootstrap --hoist",
     "clean": "lerna clean",
     "predeploy": "npm run docs",

--- a/scripts/jsdoc.conf.json
+++ b/scripts/jsdoc.conf.json
@@ -4,26 +4,9 @@
     },
     "source": {
         "include": [
-            "filters/ascii/src/",
-            "filters/bloom/src/",
-            "filters/bulge-pinch/src/",
-            "filters/color-replace/src/",
-            "filters/convolution/src/",
-            "filters/cross-hatch/src/",
-            "filters/dot/src/",
-            "filters/drop-shadow/src/",
-            "filters/emboss/src/",
-            "filters/glow/src/",
-            "filters/outline/src/",
-            "filters/pixelate/src/",
-            "filters/rgb-split/src/",
-            "filters/shockwave/src/",
-            "filters/simple-lightmap/src/",
-            "filters/tilt-shift/src/",
-            "filters/twist/src/"
+            "filters"
         ],
-        "includePattern": ".+\\.js(doc)?$",
-        "excludePattern": "(^|\\/|\\\\)_"
+        "excludePattern": "(node_modules|lib)"
     },
     "plugins": [
         "plugins/markdown",


### PR DESCRIPTION
These are small housekeeping fixes that affect the build process and Travis, nothing to do with the filters themselves.

### Fixed

* Changes NPM `postinstall` to run lerna’s bootstrap instead of bootstrap pre-running with `npm install`, to remove developer confusion. (context: #45 and https://github.com/pixijs/pixi-filters/pull/40#issue-259329927)
* Created a simpler version of JSDoc include, so that we don’t have add every new filter.