### PR TITLE
Make sure filters are rebuilt-after version bump

### DIFF
--- a/filters/all/package.json
+++ b/filters/all/package.json
@@ -25,7 +25,8 @@
   "scripts": {
     "build:umd": "rollup -c -f umd",
     "build:es": "rollup -c",
-    "build": "npm run build:umd && npm run build:es"
+    "build": "npm run build:umd && npm run build:es",
+    "postversion": "npm run build"
   },
   "peerDependencies": {
     "pixi.js": "^4.0.0"

--- a/filters/ascii/package.json
+++ b/filters/ascii/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build:umd": "rollup -c -f umd && rollup -cp -f umd",
     "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es"
+    "build": "npm run build:umd && npm run build:es",
+    "postversion": "npm run build"
   },
   "files": [
     "lib",

--- a/filters/bloom/package.json
+++ b/filters/bloom/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build:umd": "rollup -c -f umd && rollup -cp -f umd",
     "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es"
+    "build": "npm run build:umd && npm run build:es",
+    "postversion": "npm run build"
   },
   "files": [
     "lib",

--- a/filters/bulge-pinch/package.json
+++ b/filters/bulge-pinch/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build:umd": "rollup -c -f umd && rollup -cp -f umd",
     "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es"
+    "build": "npm run build:umd && npm run build:es",
+    "postversion": "npm run build"
   },
   "files": [
     "lib",

--- a/filters/color-replace/package.json
+++ b/filters/color-replace/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build:umd": "rollup -c -f umd && rollup -cp -f umd",
     "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es"
+    "build": "npm run build:umd && npm run build:es",
+    "postversion": "npm run build"
   },
   "files": [
     "lib",

--- a/filters/convolution/package.json
+++ b/filters/convolution/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build:umd": "rollup -c -f umd && rollup -cp -f umd",
     "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es"
+    "build": "npm run build:umd && npm run build:es",
+    "postversion": "npm run build"
   },
   "files": [
     "lib",

--- a/filters/cross-hatch/package.json
+++ b/filters/cross-hatch/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build:umd": "rollup -c -f umd && rollup -cp -f umd",
     "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es"
+    "build": "npm run build:umd && npm run build:es",
+    "postversion": "npm run build"
   },
   "files": [
     "lib",

--- a/filters/dot/package.json
+++ b/filters/dot/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build:umd": "rollup -c -f umd && rollup -cp -f umd",
     "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es"
+    "build": "npm run build:umd && npm run build:es",
+    "postversion": "npm run build"
   },
   "files": [
     "lib",

--- a/filters/drop-shadow/package.json
+++ b/filters/drop-shadow/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build:umd": "rollup -c -f umd && rollup -cp -f umd",
     "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es"
+    "build": "npm run build:umd && npm run build:es",
+    "postversion": "npm run build"
   },
   "files": [
     "lib",

--- a/filters/emboss/package.json
+++ b/filters/emboss/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build:umd": "rollup -c -f umd && rollup -cp -f umd",
     "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es"
+    "build": "npm run build:umd && npm run build:es",
+    "postversion": "npm run build"
   },
   "files": [
     "lib",

--- a/filters/glow/package.json
+++ b/filters/glow/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build:umd": "rollup -c -f umd && rollup -cp -f umd",
     "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es"
+    "build": "npm run build:umd && npm run build:es",
+    "postversion": "npm run build"
   },
   "files": [
     "lib",

--- a/filters/outline/package.json
+++ b/filters/outline/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build:umd": "rollup -c -f umd && rollup -cp -f umd",
     "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es"
+    "build": "npm run build:umd && npm run build:es",
+    "postversion": "npm run build"
   },
   "files": [
     "lib",

--- a/filters/pixelate/package.json
+++ b/filters/pixelate/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build:umd": "rollup -c -f umd && rollup -cp -f umd",
     "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es"
+    "build": "npm run build:umd && npm run build:es",
+    "postversion": "npm run build"
   },
   "files": [
     "lib",

--- a/filters/rgb-split/package.json
+++ b/filters/rgb-split/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build:umd": "rollup -c -f umd && rollup -cp -f umd",
     "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es"
+    "build": "npm run build:umd && npm run build:es",
+    "postversion": "npm run build"
   },
   "files": [
     "lib",

--- a/filters/shockwave/package.json
+++ b/filters/shockwave/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build:umd": "rollup -c -f umd && rollup -cp -f umd",
     "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es"
+    "build": "npm run build:umd && npm run build:es",
+    "postversion": "npm run build"
   },
   "files": [
     "lib",

--- a/filters/simple-lightmap/package.json
+++ b/filters/simple-lightmap/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build:umd": "rollup -c -f umd && rollup -cp -f umd",
     "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es"
+    "build": "npm run build:umd && npm run build:es",
+    "postversion": "npm run build"
   },
   "files": [
     "lib",

--- a/filters/tilt-shift/package.json
+++ b/filters/tilt-shift/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build:umd": "rollup -c -f umd && rollup -cp -f umd",
     "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es"
+    "build": "npm run build:umd && npm run build:es",
+    "postversion": "npm run build"
   },
   "files": [
     "lib",

--- a/filters/twist/package.json
+++ b/filters/twist/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build:umd": "rollup -c -f umd && rollup -cp -f umd",
     "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es"
+    "build": "npm run build:umd && npm run build:es",
+    "postversion": "npm run build"
   },
   "files": [
     "lib",

--- a/filters/zoom-blur/package.json
+++ b/filters/zoom-blur/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build:umd": "rollup -c -f umd && rollup -cp -f umd",
     "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es"
+    "build": "npm run build:umd && npm run build:es",
+    "postversion": "npm run build"
   },
   "files": [
     "lib",


### PR DESCRIPTION
### Issue

The version in the output, published file is not correctly matching the version in **package.json**, although the contents of the file are correct.

### Background

After researching Lerna and NPM prepublishing hooks, I discovered that packages were not being built immediately before publish. Seems there is [some disagreement](https://github.com/lerna/lerna/pull/499#issuecomment-324100681) exactly how to replicate NPM's `prepublish` (or `prepare`/`prepublishOnly` for NPM +4) in Lerna's `publish` lifecycle so decided to use `postversion` instead.


### Fix

This change builds using the `postversion` hook in the Lerna [publishing lifecycle](https://github.com/lerna/lerna/blob/master/src/commands/PublishCommand.js#L623).