### PR TITLE
Add obj.arguments for `required arguments`

### DIFF
--- a/tools/screenshots/renderer.js
+++ b/tools/screenshots/renderer.js
@@ -66,7 +66,7 @@ function next() {
                 break;
             }
             default: {
-                var args = obj.arguments;
+                const args = obj.arguments;
                 if (args) {
                     filter = new FilterClass(...args);
                 } else {

--- a/tools/screenshots/renderer.js
+++ b/tools/screenshots/renderer.js
@@ -66,7 +66,12 @@ function next() {
                 break;
             }
             default: {
-                filter = new FilterClass();
+                var args = obj.arguments;
+                if (args) {
+                    filter = new FilterClass(...args);
+                } else {
+                    filter = new FilterClass();
+                }
             }
         }
 


### PR DESCRIPTION
Sometimes , the filter with `required arguments` ,  call `new FilterClass()` directly will take some errors.

If add `obj.arguments` feature , filter developer could  add arguments in  config.json like this: 
```
        {
            "name": "MultiColorReplaceFilter",
            "filename": "multi-color-replace",
            "arguments": [
                [3238359, 938417, 1464209],
                [16711680, 65280, 16776960],
                0.2
            ]
        },
```