### PR TITLE
Rename some properties & update some annotations

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -319,8 +319,8 @@
                 folder = gui.addFolder('AdvancedBloomFilter');
                 folder.add(advancedBloomFilter, 'enabled').onChange(trackEvent.bind(folder));
                 folder.add(advancedBloomFilter, 'threshold', 0.1, 0.9);
+                folder.add(advancedBloomFilter, 'bloomScale', 0.5, 1.5);
                 folder.add(advancedBloomFilter, 'brightness', 0.5, 1.5);
-                folder.add(advancedBloomFilter, 'contrast', 0.5, 1.5);
                 folder.add(advancedBloomFilter, 'blur', 0, 20);
 
                 var tiltshiftFilter = new PIXI.filters.TiltShiftFilter();

--- a/filters/advanced-bloom/src/AdvancedBloomFilter.js
+++ b/filters/advanced-bloom/src/AdvancedBloomFilter.js
@@ -14,9 +14,9 @@ import fragment from './advanced-bloom.frag';
  *
  * @param {object|number} [options] - The optional parameters of advanced bloom filter.
  *                        When options is a number , it will be `options.threshold`.
- * @param {number} [options.threshold=0.5] - The minimum amount of brightness considered when applying bloom. 
- * @param {number} [options.brightness=1.0] - The strength of the brightness, higher values is more intense brightness.
- * @param {number} [options.contrast=1.0] - The contrast, lower value is more subtle brightness, higher value is blown-out.
+ * @param {number} [options.threshold=0.5] - Defines how bright a color needs to be to affect bloom.
+ * @param {number} [options.bloomScale=1.0] - To adjust the strength of the bloom. Higher values is more intense brightness.
+ * @param {number} [options.brightness=1.0] - The brightness, lower value is more subtle brightness, higher value is blown-out.
  * @param {number} [options.blur=8] - Sets the strength of both the blurX and blurY properties simultaneously
  * @param {number} [options.quality=4] - The quality of the blurX & blurY filter.
  * @param {number} [options.resolution=PIXI.settings.RESOLUTION] - The resolution of the blurX & blurY filter.
@@ -34,8 +34,8 @@ export default class AdvancedBloomFilter extends PIXI.Filter {
 
         options = Object.assign({
             threshold: 0.5,
+            bloomScale: 1.0,
             brightness: 1.0,
-            contrast: 1.0,
             blur: 8,
             quality: 4,
             resolution: PIXI.settings.RESOLUTION,
@@ -44,20 +44,20 @@ export default class AdvancedBloomFilter extends PIXI.Filter {
 
 
         /**
-         * The strength of the brightness, higher values is more intense brightness.
+         * To adjust the strength of the bloom. Higher values is more intense brightness.
+         *
+         * @member {number}
+         * @default 1.0
+         */
+        this.bloomScale = options.bloomScale;
+
+        /**
+         * The brightness, lower value is more subtle brightness, higher value is blown-out.
          *
          * @member {number}
          * @default 1.0
          */
         this.brightness = options.brightness;
-
-        /**
-         * The contrast, lower value is more subtle brightness, higher value is blown-out.
-         *
-         * @member {number}
-         * @default 1.0
-         */
-        this.contrast = options.contrast;
 
         const { blur, quality, resolution, kernelSize } = options;
         const { BlurXFilter, BlurYFilter } = PIXI.filters;
@@ -79,8 +79,8 @@ export default class AdvancedBloomFilter extends PIXI.Filter {
         this._blurX.apply(filterManager, brightTarget, brightTarget, true, currentState);
         this._blurY.apply(filterManager, brightTarget, brightTarget, true, currentState);
 
+        this.uniforms.bloomScale = this.bloomScale;
         this.uniforms.brightness = this.brightness;
-        this.uniforms.contrast = this.contrast;
         this.uniforms.bloomTexture = brightTarget;
 
         filterManager.applyFilter(this, input, output, clear);
@@ -89,7 +89,7 @@ export default class AdvancedBloomFilter extends PIXI.Filter {
     }
 
     /**
-     * The threshold brightness for applying bloom, lower value is more brightness.
+     * Defines how bright a color needs to be to affect bloom.
      *
      * @member {number}
      * @default 0.5
@@ -117,4 +117,3 @@ export default class AdvancedBloomFilter extends PIXI.Filter {
 
 // Export to PixiJS namespace
 PIXI.filters.AdvancedBloomFilter = AdvancedBloomFilter;
-

--- a/filters/advanced-bloom/src/ExtractBrightnessFilter.js
+++ b/filters/advanced-bloom/src/ExtractBrightnessFilter.js
@@ -16,7 +16,7 @@ export default class ExtractBrightnessFilter extends PIXI.Filter {
     }
 
     /**
-     * efines how bright a color needs to be extracted.
+     * Defines how bright a color needs to be extracted.
      *
      * @member {number}
      * @default 0.5

--- a/filters/advanced-bloom/src/ExtractBrightnessFilter.js
+++ b/filters/advanced-bloom/src/ExtractBrightnessFilter.js
@@ -5,7 +5,7 @@ import fragment from './extract-brightness.frag';
  * Internal filter for AdvancedBloomFilter to get brightness.
  * @class
  * @private
- * @param {number} [threshold=0.5] The minimum amount of brightness considered.
+ * @param {number} [threshold=0.5] Defines how bright a color needs to be extracted.
  */
 export default class ExtractBrightnessFilter extends PIXI.Filter {
 
@@ -16,7 +16,7 @@ export default class ExtractBrightnessFilter extends PIXI.Filter {
     }
 
     /**
-     * The minimum amount of brightness considered.
+     * efines how bright a color needs to be extracted.
      *
      * @member {number}
      * @default 0.5

--- a/filters/advanced-bloom/src/advanced-bloom.frag
+++ b/filters/advanced-bloom/src/advanced-bloom.frag
@@ -2,13 +2,13 @@ uniform sampler2D uSampler;
 varying vec2 vTextureCoord;
 
 uniform sampler2D bloomTexture;
+uniform float bloomScale;
 uniform float brightness;
-uniform float contrast;
 
 void main() {
     vec4 color = texture2D(uSampler, vTextureCoord);
-    color.rgb *= contrast;
+    color.rgb *= brightness;
     vec4 bloomColor = vec4(texture2D(bloomTexture, vTextureCoord).rgb, 0.0);
-    bloomColor.rgb *= brightness;
+    bloomColor.rgb *= bloomScale;
     gl_FragColor = color + bloomColor;
 }

--- a/filters/advanced-bloom/src/extract-brightness.frag
+++ b/filters/advanced-bloom/src/extract-brightness.frag
@@ -13,9 +13,9 @@ void main() {
     float _min = min(min(color.r, color.g), color.b);
     float brightness = (_max + _min) * 0.5;
 
-    if(brightness < threshold) {
-        gl_FragColor = vec4(0.0, 0.0, 0.0, 0.0);
-    } else {
+    if(brightness > threshold) {
         gl_FragColor = color;
+    } else {
+        gl_FragColor = vec4(0.0, 0.0, 0.0, 0.0);
     }
 }

--- a/filters/advanced-bloom/types.d.ts
+++ b/filters/advanced-bloom/types.d.ts
@@ -4,14 +4,14 @@ declare namespace PIXI.filters {
         constructor(options?: AdvancedBloomOptions);
         constructor(threshold?: number);
         threshold: number;
+        bloomScale: number;
         brightness: number;
-        contrast: number;
         blur: number;
     }
     interface AdvancedBloomOptions {
         threshold?: number;
+        bloomScale?: number;
         brightness?: number;
-        contrast?: number;
         blur?: number;
         quality?: number;
         resolution?: number;

--- a/filters/all/types.d.ts
+++ b/filters/all/types.d.ts
@@ -8,14 +8,14 @@ declare namespace PIXI.filters {
         constructor(options?: AdvancedBloomOptions);
         constructor(threshold?: number);
         threshold: number;
+        bloomScale: number;
         brightness: number;
-        contrast: number;
         blur: number;
     }
     interface AdvancedBloomOptions {
         threshold?: number;
+        bloomScale?: number;
         brightness?: number;
-        contrast?: number;
         blur?: number;
         quality?: number;
         resolution?: number;


### PR DESCRIPTION
Rename some properties ( read unreal engine doc for reference): 
```
brightness --> bloomScale : 
    because this property is only for changing the bloom's strength, not the overall brightness.
```
```
contrast --> brightness: 
    because this property will change the overall brightness , not contrast
```