### PR TITLE
Remove trailing-white-space

### DIFF
--- a/filters/multi-color-replace/src/MultiColorReplaceFilter.js
+++ b/filters/multi-color-replace/src/MultiColorReplaceFilter.js
@@ -14,7 +14,7 @@ import fragment from './multi-color-replace.frag';
  *                                  (lower = more exact, higher = more inclusive)
  * @param {number} [maxColors] - The maximum number of replacements filter is able to use. Because the
  *                               fragment is only compiled once, this cannot be changed after construction.
- *                               If omitted, the default value is the length of `replacements`.     
+ *                               If omitted, the default value is the length of `replacements`.
  *
  * @example
  *  // replaces pure red with pure blue, and replaces pure green with pure white
@@ -67,7 +67,7 @@ export default class MultiColorReplaceFilter extends PIXI.Filter
         {
             throw `Length of replacements (${colorCount}) exceeds the maximum colors length (${this._maxColors})`;
         }
-        
+
         // Fill with negative values
         originals[colorCount * 3] = -1;
 


### PR DESCRIPTION
I suggest the developers of PIXI team could install some plugins for `remove trailing-white-space` in their code editor.

BTW , I use sublime text 3 , the feature built in it.