### PR TITLE
Build Process Improvements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,6 +48,9 @@
         ],
         "no-console": [
             "warn"
+        ],
+        "no-trailing-spaces": [
+            "error"
         ]
     }
 }

--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ Build multiple filters where scope is a glob expression:
 npm run build -- --scope "{@pixi/filter-emboss,@pixi/filter-glow}"
 ```
 
+Watch all filters (auto-rebuild upon src changes):
+
+```bash
+npm run watch
+```
+
+Build all filters in dev-mode (un-minified):
+
+```bash
+npm run build:dev
+```
+
 ## Documentation
 
 API documention can be found [here](http://pixijs.github.io/pixi-filters/docs/).

--- a/filters/advanced-bloom/package.json
+++ b/filters/advanced-bloom/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pixi/filter-advanced-bloom",
   "version": "2.2.0",
-  "main": "lib/filter-advanced-bloom.min.js",
+  "main": "lib/filter-advanced-bloom.js",
   "description": "Display filter render as ASCII text",
   "author": "finscn",
   "contributors": [
     "finscn <finscn@gmail.com>"
   ],
-  "module": "lib/filter-advanced-bloom.es.min.js",
+  "module": "lib/filter-advanced-bloom.es.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -20,9 +20,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:umd": "rollup -c -f umd && rollup -cp -f umd",
-    "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "rollup -c && rollup -c -f umd",
+    "build": "rollup -cp && rollup -cp -f umd",
+    "watch": "rollup -cw",
     "postversion": "npm run build"
   },
   "files": [
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@tools/build": "^2.0.1",
     "@tools/fragments": "^2.0.0",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/all/package.json
+++ b/filters/all/package.json
@@ -23,9 +23,9 @@
     "types.d.ts"
   ],
   "scripts": {
-    "build:umd": "rollup -c -f umd",
-    "build:es": "rollup -c",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "npm run build",
+    "build": "rollup -c && rollup -c -f umd",
+    "watch": "rollup -cw -f umd",
     "postversion": "npm run build"
   },
   "peerDependencies": {
@@ -54,6 +54,7 @@
     "@pixi/filter-twist": "^2.2.0",
     "@pixi/filter-zoom-blur": "^2.2.0",
     "@tools/build": "^2.0.1",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/all/src/index.js
+++ b/filters/all/src/index.js
@@ -19,3 +19,4 @@ export {SimpleLightmapFilter} from '@pixi/filter-simple-lightmap';
 export {TiltShiftFilter, TiltShiftAxisFilter, TiltShiftXFilter, TiltShiftYFilter} from '@pixi/filter-tilt-shift';
 export {TwistFilter} from '@pixi/filter-twist';
 export {ZoomBlurFilter} from '@pixi/filter-zoom-blur';
+

--- a/filters/ascii/package.json
+++ b/filters/ascii/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pixi/filter-ascii",
   "version": "2.2.0",
-  "main": "lib/filter-ascii.min.js",
+  "main": "lib/filter-ascii.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "lib/filter-ascii.es.min.js",
+  "module": "lib/filter-ascii.es.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -20,9 +20,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:umd": "rollup -c -f umd && rollup -cp -f umd",
-    "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "rollup -c && rollup -c -f umd",
+    "build": "rollup -cp && rollup -cp -f umd",
+    "watch": "rollup -cw",
     "postversion": "npm run build"
   },
   "files": [
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@tools/build": "^2.0.1",
     "@tools/fragments": "^2.0.0",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/bloom/package.json
+++ b/filters/bloom/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pixi/filter-bloom",
   "version": "2.2.0",
-  "main": "lib/filter-bloom.min.js",
+  "main": "lib/filter-bloom.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "lib/filter-bloom.es.min.js",
+  "module": "lib/filter-bloom.es.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -20,9 +20,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:umd": "rollup -c -f umd && rollup -cp -f umd",
-    "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "rollup -c && rollup -c -f umd",
+    "build": "rollup -cp && rollup -cp -f umd",
+    "watch": "rollup -cw",
     "postversion": "npm run build"
   },
   "files": [
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@tools/build": "^2.0.1",
     "@tools/fragments": "^2.0.0",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/bulge-pinch/package.json
+++ b/filters/bulge-pinch/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pixi/filter-bulge-pinch",
   "version": "2.2.0",
-  "main": "lib/filter-bulge-pinch.min.js",
+  "main": "lib/filter-bulge-pinch.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "lib/filter-bulge-pinch.es.min.js",
+  "module": "lib/filter-bulge-pinch.es.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -20,9 +20,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:umd": "rollup -c -f umd && rollup -cp -f umd",
-    "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "rollup -c && rollup -c -f umd",
+    "build": "rollup -cp && rollup -cp -f umd",
+    "watch": "rollup -cw",
     "postversion": "npm run build"
   },
   "files": [
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@tools/build": "^2.0.1",
     "@tools/fragments": "^2.0.0",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/color-replace/package.json
+++ b/filters/color-replace/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pixi/filter-color-replace",
   "version": "2.2.0",
-  "main": "lib/filter-color-replace.min.js",
+  "main": "lib/filter-color-replace.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "lib/filter-color-replace.es.min.js",
+  "module": "lib/filter-color-replace.es.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -20,9 +20,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:umd": "rollup -c -f umd && rollup -cp -f umd",
-    "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "rollup -c && rollup -c -f umd",
+    "build": "rollup -cp && rollup -cp -f umd",
+    "watch": "rollup -cw",
     "postversion": "npm run build"
   },
   "files": [
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@tools/build": "^2.0.1",
     "@tools/fragments": "^2.0.0",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/convolution/package.json
+++ b/filters/convolution/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pixi/filter-convolution",
   "version": "2.2.0",
-  "main": "lib/filter-convolution.min.js",
+  "main": "lib/filter-convolution.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "lib/filter-convolution.es.min.js",
+  "module": "lib/filter-convolution.es.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -20,9 +20,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:umd": "rollup -c -f umd && rollup -cp -f umd",
-    "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "rollup -c && rollup -c -f umd",
+    "build": "rollup -cp && rollup -cp -f umd",
+    "watch": "rollup -cw",
     "postversion": "npm run build"
   },
   "files": [
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@tools/build": "^2.0.1",
     "@tools/fragments": "^2.0.0",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/cross-hatch/package.json
+++ b/filters/cross-hatch/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pixi/filter-cross-hatch",
   "version": "2.2.0",
-  "main": "lib/filter-cross-hatch.min.js",
+  "main": "lib/filter-cross-hatch.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "lib/filter-cross-hatch.es.min.js",
+  "module": "lib/filter-cross-hatch.es.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -20,9 +20,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:umd": "rollup -c -f umd && rollup -cp -f umd",
-    "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "rollup -c && rollup -c -f umd",
+    "build": "rollup -cp && rollup -cp -f umd",
+    "watch": "rollup -cw",
     "postversion": "npm run build"
   },
   "files": [
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@tools/build": "^2.0.1",
     "@tools/fragments": "^2.0.0",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/dot/package.json
+++ b/filters/dot/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pixi/filter-dot",
   "version": "2.2.0",
-  "main": "lib/filter-dot.min.js",
+  "main": "lib/filter-dot.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "lib/filter-dot.es.min.js",
+  "module": "lib/filter-dot.es.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -20,9 +20,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:umd": "rollup -c -f umd && rollup -cp -f umd",
-    "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "rollup -c && rollup -c -f umd",
+    "build": "rollup -cp && rollup -cp -f umd",
+    "watch": "rollup -cw",
     "postversion": "npm run build"
   },
   "files": [
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@tools/build": "^2.0.1",
     "@tools/fragments": "^2.0.0",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/drop-shadow/package.json
+++ b/filters/drop-shadow/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pixi/filter-drop-shadow",
   "version": "2.2.0",
-  "main": "lib/filter-drop-shadow.min.js",
+  "main": "lib/filter-drop-shadow.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "lib/filter-drop-shadow.es.min.js",
+  "module": "lib/filter-drop-shadow.es.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -20,9 +20,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:umd": "rollup -c -f umd && rollup -cp -f umd",
-    "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "rollup -c && rollup -c -f umd",
+    "build": "rollup -cp && rollup -cp -f umd",
+    "watch": "rollup -cw",
     "postversion": "npm run build"
   },
   "files": [
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@tools/build": "^2.0.1",
     "@tools/fragments": "^2.0.0",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/emboss/package.json
+++ b/filters/emboss/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pixi/filter-emboss",
   "version": "2.2.0",
-  "main": "lib/filter-emboss.min.js",
+  "main": "lib/filter-emboss.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "lib/filter-emboss.es.min.js",
+  "module": "lib/filter-emboss.es.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -20,9 +20,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:umd": "rollup -c -f umd && rollup -cp -f umd",
-    "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "rollup -c && rollup -c -f umd",
+    "build": "rollup -cp && rollup -cp -f umd",
+    "watch": "rollup -cw",
     "postversion": "npm run build"
   },
   "files": [
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@tools/build": "^2.0.1",
     "@tools/fragments": "^2.0.0",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/glow/package.json
+++ b/filters/glow/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pixi/filter-glow",
   "version": "2.2.0",
-  "main": "lib/filter-glow.min.js",
+  "main": "lib/filter-glow.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "lib/filter-glow.es.min.js",
+  "module": "lib/filter-glow.es.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -20,9 +20,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:umd": "rollup -c -f umd && rollup -cp -f umd",
-    "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "rollup -c && rollup -c -f umd",
+    "build": "rollup -cp && rollup -cp -f umd",
+    "watch": "rollup -cw",
     "postversion": "npm run build"
   },
   "files": [
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@tools/build": "^2.0.1",
     "@tools/fragments": "^2.0.0",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/godray/package.json
+++ b/filters/godray/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@pixi/filter-godray",
   "version": "2.2.0",
-  "main": "lib/filter-godray.min.js",
+  "main": "lib/filter-godray.js",
   "description": "Display filter gorday",
   "author": "Alain Galvan",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>",
     "Ivan Popelyshevl <ivan.popelyshev@gmail.com>"
   ],
-  "module": "lib/filter-godray.es.min.js",
+  "module": "lib/filter-godray.es.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -21,9 +21,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:umd": "rollup -c -f umd && rollup -cp -f umd",
-    "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "rollup -c && rollup -c -f umd",
+    "build": "rollup -cp && rollup -cp -f umd",
+    "watch": "rollup -cw",
     "postversion": "npm run build"
   },
   "files": [
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@tools/build": "^2.0.1",
     "@tools/fragments": "^2.0.0",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/godray/src/GodrayFilter.js
+++ b/filters/godray/src/GodrayFilter.js
@@ -22,7 +22,7 @@ import main from './main.frag';
 export default class GodrayFilter extends PIXI.Filter {
 
     constructor(angle = 30, gain = 0.5, lacunarity = 2.5, time = 0) {
-        super(vertex, main.replace("$perlin", perlin));
+        super(vertex, main.replace('$perlin', perlin));
 
         /**
          * The angle of the rays in degrees. For instance, a value of 0 is vertical rays,

--- a/filters/multi-color-replace/package.json
+++ b/filters/multi-color-replace/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pixi/filter-multi-color-replace",
   "version": "2.2.0",
-  "main": "lib/filter-multi-color-replace.min.js",
+  "main": "lib/filter-multi-color-replace.js",
   "description": "Multi Color Replace filter",
   "author": "finscn",
   "contributors": [
     "finscn <finscn@gmail.com>"
   ],
-  "module": "lib/filter-multi-color-replace.es.min.js",
+  "module": "lib/filter-multi-color-replace.es.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -20,9 +20,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:umd": "rollup -c -f umd && rollup -cp -f umd",
-    "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "rollup -c && rollup -c -f umd",
+    "build": "rollup -cp && rollup -cp -f umd",
+    "watch": "rollup -cw",
     "postversion": "npm run build"
   },
   "files": [
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@tools/build": "^2.0.1",
     "@tools/fragments": "^2.0.0",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/multi-color-replace/src/MultiColorReplaceFilter.js
+++ b/filters/multi-color-replace/src/MultiColorReplaceFilter.js
@@ -36,10 +36,8 @@ import fragment from './multi-color-replace.frag';
  *  )];
  *
  */
-export default class MultiColorReplaceFilter extends PIXI.Filter
-{
-    constructor(replacements, epsilon = 0.05, maxColors = null)
-    {
+export default class MultiColorReplaceFilter extends PIXI.Filter {
+    constructor(replacements, epsilon = 0.05, maxColors = null) {
         maxColors = maxColors || replacements.length;
 
         super(vertex, fragment.replace(/%maxColors%/g, maxColors));
@@ -57,32 +55,27 @@ export default class MultiColorReplaceFilter extends PIXI.Filter
      *
      * @member {Array<Array>}
      */
-    set replacements(replacements)
-    {
+    set replacements(replacements) {
         const originals = this.uniforms.originalColors;
         const targets = this.uniforms.targetColors;
         const colorCount = replacements.length;
 
-        if (colorCount > this._maxColors)
-        {
+        if (colorCount > this._maxColors) {
             throw `Length of replacements (${colorCount}) exceeds the maximum colors length (${this._maxColors})`;
         }
 
         // Fill with negative values
         originals[colorCount * 3] = -1;
 
-        for (let i = 0; i < colorCount; i++)
-        {
+        for (let i = 0; i < colorCount; i++) {
             const pair = replacements[i];
 
             // for original colors
             let color = pair[0];
-            if (typeof color === 'number')
-            {
+            if (typeof color === 'number') {
                 color = PIXI.utils.hex2rgb(color);
             }
-            else
-            {
+            else {
                 pair[0] = PIXI.utils.rgb2hex(color);
             }
 
@@ -92,12 +85,10 @@ export default class MultiColorReplaceFilter extends PIXI.Filter
 
             // for target colors
             let targetColor = pair[1];
-            if (typeof targetColor === 'number')
-            {
+            if (typeof targetColor === 'number') {
                 targetColor = PIXI.utils.hex2rgb(targetColor);
             }
-            else
-            {
+            else {
                 pair[1] = PIXI.utils.rgb2hex(targetColor);
             }
 
@@ -108,8 +99,7 @@ export default class MultiColorReplaceFilter extends PIXI.Filter
 
         this._replacements = replacements;
     }
-    get replacements()
-    {
+    get replacements() {
         return this._replacements;
     }
 
@@ -138,12 +128,10 @@ export default class MultiColorReplaceFilter extends PIXI.Filter
      * @member {number}
      * @default 0.05
      */
-    set epsilon(value)
-    {
+    set epsilon(value) {
         this.uniforms.epsilon = value;
     }
-    get epsilon()
-    {
+    get epsilon() {
         return this.uniforms.epsilon;
     }
 }

--- a/filters/outline/package.json
+++ b/filters/outline/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pixi/filter-outline",
   "version": "2.2.0",
-  "main": "lib/filter-outline.min.js",
+  "main": "lib/filter-outline.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "lib/filter-outline.es.min.js",
+  "module": "lib/filter-outline.es.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -20,9 +20,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:umd": "rollup -c -f umd && rollup -cp -f umd",
-    "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "rollup -c && rollup -c -f umd",
+    "build": "rollup -cp && rollup -cp -f umd",
+    "watch": "rollup -cw",
     "postversion": "npm run build"
   },
   "files": [
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@tools/build": "^2.0.1",
     "@tools/fragments": "^2.0.0",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/pixelate/package.json
+++ b/filters/pixelate/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pixi/filter-pixelate",
   "version": "2.2.0",
-  "main": "lib/filter-pixelate.min.js",
+  "main": "lib/filter-pixelate.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "lib/filter-pixelate.es.min.js",
+  "module": "lib/filter-pixelate.es.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -20,9 +20,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:umd": "rollup -c -f umd && rollup -cp -f umd",
-    "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "rollup -c && rollup -c -f umd",
+    "build": "rollup -cp && rollup -cp -f umd",
+    "watch": "rollup -cw",
     "postversion": "npm run build"
   },
   "files": [
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@tools/build": "^2.0.1",
     "@tools/fragments": "^2.0.0",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/rgb-split/package.json
+++ b/filters/rgb-split/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pixi/filter-rgb-split",
   "version": "2.2.0",
-  "main": "lib/filter-rgb-split.min.js",
+  "main": "lib/filter-rgb-split.js",
   "description": "Display filter render as rgb-split text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "lib/filter-rgb-split.es.min.js",
+  "module": "lib/filter-rgb-split.es.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -20,9 +20,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:umd": "rollup -c -f umd && rollup -cp -f umd",
-    "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "rollup -c && rollup -c -f umd",
+    "build": "rollup -cp && rollup -cp -f umd",
+    "watch": "rollup -cw",
     "postversion": "npm run build"
   },
   "files": [
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@tools/build": "^2.0.1",
     "@tools/fragments": "^2.0.0",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/shockwave/package.json
+++ b/filters/shockwave/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pixi/filter-shockwave",
   "version": "2.2.0",
-  "main": "lib/filter-shockwave.min.js",
+  "main": "lib/filter-shockwave.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "lib/filter-shockwave.es.min.js",
+  "module": "lib/filter-shockwave.es.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -20,9 +20,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:umd": "rollup -c -f umd && rollup -cp -f umd",
-    "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "rollup -c && rollup -c -f umd",
+    "build": "rollup -cp && rollup -cp -f umd",
+    "watch": "rollup -cw",
     "postversion": "npm run build"
   },
   "files": [
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@tools/build": "^2.0.1",
     "@tools/fragments": "^2.0.0",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/simple-lightmap/package.json
+++ b/filters/simple-lightmap/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pixi/filter-simple-lightmap",
   "version": "2.2.0",
-  "main": "lib/filter-simple-lightmap.min.js",
+  "main": "lib/filter-simple-lightmap.js",
   "description": "Display filter render as simple-lightmap text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "lib/filter-simple-lightmap.es.min.js",
+  "module": "lib/filter-simple-lightmap.es.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -20,9 +20,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:umd": "rollup -c -f umd && rollup -cp -f umd",
-    "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "rollup -c && rollup -c -f umd",
+    "build": "rollup -cp && rollup -cp -f umd",
+    "watch": "rollup -cw",
     "postversion": "npm run build"
   },
   "files": [
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@tools/build": "^2.0.1",
     "@tools/fragments": "^2.0.0",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/simple-lightmap/src/SimpleLightmapFilter.js
+++ b/filters/simple-lightmap/src/SimpleLightmapFilter.js
@@ -40,8 +40,7 @@ export default class SimpleLightmapFilter extends PIXI.Filter {
      * @param {PIXI.RenderTarget} input - The input target.
      * @param {PIXI.RenderTarget} output - The output target.
      */
-    apply(filterManager, input, output, clear)
-    {
+    apply(filterManager, input, output, clear) {
         this.uniforms.dimensions[0] = input.sourceFrame.width;
         this.uniforms.dimensions[1] = input.sourceFrame.height;
 

--- a/filters/tilt-shift/package.json
+++ b/filters/tilt-shift/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pixi/filter-tilt-shift",
   "version": "2.2.0",
-  "main": "lib/filter-tilt-shift.min.js",
+  "main": "lib/filter-tilt-shift.js",
   "description": "Display filter render as tilt-shift text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "lib/filter-tilt-shift.es.min.js",
+  "module": "lib/filter-tilt-shift.es.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -20,9 +20,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:umd": "rollup -c -f umd && rollup -cp -f umd",
-    "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "rollup -c && rollup -c -f umd",
+    "build": "rollup -cp && rollup -cp -f umd",
+    "watch": "rollup -cw",
     "postversion": "npm run build"
   },
   "files": [
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@tools/build": "^2.0.1",
     "@tools/fragments": "^2.0.0",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/twist/package.json
+++ b/filters/twist/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pixi/filter-twist",
   "version": "2.2.0",
-  "main": "lib/filter-twist.min.js",
+  "main": "lib/filter-twist.js",
   "description": "Display filter render as twist text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
-  "module": "lib/filter-twist.es.min.js",
+  "module": "lib/filter-twist.es.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -20,9 +20,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:umd": "rollup -c -f umd && rollup -cp -f umd",
-    "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "rollup -c && rollup -c -f umd",
+    "build": "rollup -cp && rollup -cp -f umd",
+    "watch": "rollup -cw",
     "postversion": "npm run build"
   },
   "files": [
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@tools/build": "^2.0.1",
     "@tools/fragments": "^2.0.0",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/zoom-blur/package.json
+++ b/filters/zoom-blur/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@pixi/filter-zoom-blur",
   "version": "2.2.0",
-  "main": "lib/filter-zoom-blur.min.js",
+  "main": "lib/filter-zoom-blur.js",
   "description": "Zoom Blur filter",
   "author": "finscn",
   "contributors": [
     "finscn <finscn@gmail.com>"
   ],
-  "module": "lib/filter-zoom-blur.es.min.js",
+  "module": "lib/filter-zoom-blur.es.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -20,9 +20,9 @@
     "access": "public"
   },
   "scripts": {
-    "build:umd": "rollup -c -f umd && rollup -cp -f umd",
-    "build:es": "rollup -c && rollup -cp",
-    "build": "npm run build:umd && npm run build:es",
+    "build:dev": "rollup -c && rollup -c -f umd",
+    "build": "rollup -cp && rollup -cp -f umd",
+    "watch": "rollup -cw",
     "postversion": "npm run build"
   },
   "files": [
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@tools/build": "^2.0.1",
     "@tools/fragments": "^2.0.0",
-    "rollup": "^0.45.2"
+    "rollup": "^0.45.2",
+    "rollup-watch": "^4.3.1"
   }
 }

--- a/filters/zoom-blur/src/ZoomBlurFilter.js
+++ b/filters/zoom-blur/src/ZoomBlurFilter.js
@@ -13,8 +13,7 @@ import fragment from './zoom-blur.frag';
  * @param {number} [innerRadius=0] The inner radius of zoom. The part in inner circle won't apply zoom blur effect.
  * @param {number} [radius=-1] See `radius` property.
  */
-export default class ZoomBlurFilter extends PIXI.Filter
-{
+export default class ZoomBlurFilter extends PIXI.Filter {
     constructor(strength = 0.1, center = [0, 0], innerRadius = 0, radius = -1) {
         super(vertex, fragment);
 

--- a/package.json
+++ b/package.json
@@ -3,16 +3,22 @@
   "scripts": {
     "postinstall": "npm run bootstrap",
     "bootstrap": "lerna bootstrap --hoist",
+    "preclean": "rimraf filters/*/lib tools/screenshots/dist",
     "clean": "lerna clean",
     "predeploy": "npm run docs",
     "test": "npm run build -- --ignore @tools/screenshots",
     "deploy": "node scripts/deploy",
     "docs": "jsdoc -c scripts/jsdoc.conf.json -R README.md",
-    "lint": "eslint scripts **/src **/rollup.config.js --fix",
+    "lint": "eslint scripts filters/*/src tools/*/*.js **/rollup.config.js --fix",
     "examples": "open http://localhost:8080/examples/index.html && http-server . -s -c-1",
-    "prebuild": "npm run lint",
+    "prebuild": "npm run lint && npm run preclean",
     "build": "lerna run build",
-    "lerna": "lerna"
+    "build:dev": "lerna run build:dev",
+    "watch": "lerna run --parallel watch",
+    "lerna": "lerna",
+    "prepub": "npm run build",
+    "pub": "lerna publish",
+    "postpub": "npm run deploy"
   },
   "devDependencies": {
     "@pixi/jsdoc-template": "^2.0.0",
@@ -20,6 +26,7 @@
     "gh-pages": "^0.11.0",
     "http-server": "^0.9.0",
     "jsdoc": "^3.4.0",
-    "lerna": "^2.0.0"
+    "lerna": "^2.0.0",
+    "rimraf": "^2.6.2"
   }
 }

--- a/tools/build/index.js
+++ b/tools/build/index.js
@@ -8,7 +8,7 @@ const minimist = require('minimist');
 
 const pkg = require(path.resolve('./package'));
 const name = path.basename(pkg.name);
-const entry = `src/index.js`;
+const entry = 'src/index.js';
 
 const {prod, format} = minimist(process.argv.slice(2), {
     string: ['format'],
@@ -23,9 +23,8 @@ const {prod, format} = minimist(process.argv.slice(2), {
     }
 });
 
-const suffix = prod ? `.min` : '';
 const formatSuffix = format === 'es' ? `.${format}` : '';
-const dest = `lib/${name}${formatSuffix}${suffix}.js`;
+const dest = `lib/${name}${formatSuffix}.js`;
 
 const plugins = [
     resolve(),
@@ -69,7 +68,7 @@ const moduleName = `__${name.replace(/-/g, '_')}`;
 let intro = '';
 
 if (!prod) {
-    intro = `if (typeof PIXI === 'undefined' || typeof PIXI.filters === 'undefined') { throw 'PixiJS is required'; }`;
+    intro = 'if (typeof PIXI === \'undefined\' || typeof PIXI.filters === \'undefined\') { throw \'PixiJS is required\'; }';
 }
 
 module.exports = {

--- a/tools/screenshots/renderer.js
+++ b/tools/screenshots/renderer.js
@@ -57,11 +57,11 @@ function next() {
         assert(!!FilterClass, `Filter ${obj.name} does not exist`);
         let filter;
         switch(obj.name) {
-            case "DisplacementFilter": {
+            case 'DisplacementFilter': {
                 filter = new FilterClass(displacement, 50);
                 break;
             }
-            case "SimpleLightmapFilter": {
+            case 'SimpleLightmapFilter': {
                 filter = new FilterClass(lightmap);
                 break;
             }
@@ -69,7 +69,8 @@ function next() {
                 const args = obj.arguments;
                 if (args) {
                     filter = new FilterClass(...args);
-                } else {
+                }
+                else {
                     filter = new FilterClass();
                 }
             }


### PR DESCRIPTION
### Changed

* Adds the ability to watch all filters and rebuild automatically by running `npm run watch`
* No longer publish minified and unminified files, only minified files will be published
* Adds `npm run build:dev` to build all the files in unminified mode, for testing purposes
* Fixes ESLint not picking up src folder in filters (glob not working)
* Adds ESlint rule for no trailing whitespace.
* Adds a publish command `npm run pub`, to make it easier to publish