### PR TITLE
Fixes Typings

### DIFF
--- a/bundle/types.d.ts
+++ b/bundle/types.d.ts
@@ -1,10 +1,10 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class AsciiFilter extends PIXI.Filter {
+    class AsciiFilter extends PIXI.Filter<{}> {
         constructor(size?:number);
         size:number;
     }
-    class AdvancedBloomFilter extends PIXI.Filter {
+    class AdvancedBloomFilter extends PIXI.Filter<{}> {
         constructor(options?: AdvancedBloomOptions);
         constructor(threshold?: number);
         threshold: number;
@@ -21,39 +21,39 @@ declare namespace PIXI.filters {
         resolution?: number;
         kernelSize?: number;
     }
-    class BloomFilter extends PIXI.Filter {
+    class BloomFilter extends PIXI.Filter<{}> {
         constructor(blur?:number|PIXI.Point|number[], quality?:number, resolution?:number, kernelSize?:number);
         blur:number;
         blurX:number;
         blurY:number;
     }
-    class BulgePinchFilter extends PIXI.Filter {
+    class BulgePinchFilter extends PIXI.Filter<{}> {
         constructor(center?:PIXI.Point|number[], radius?:number, strength?:number);
         center:PIXI.Point;
         radius:number;
         strength:number;
     }
-    class ColorReplaceFilter extends PIXI.Filter {
+    class ColorReplaceFilter extends PIXI.Filter<{}> {
         constructor(originalColor?:number|number[], newColor?:number|number[], epsilon?:number);
         epsilon:number;
         originalColor:number|number[];
         newColor:number|number[];
     }
-    class ConvolutionFilter extends PIXI.Filter {
+    class ConvolutionFilter extends PIXI.Filter<{}> {
         constructor(matrix:number[], width:number, height:number);
         height:number;
         width:number;
         matrix:number[];
     }
-    class CrossHatchFilter extends PIXI.Filter {
+    class CrossHatchFilter extends PIXI.Filter<{}> {
         constructor();
     }
-    class DotFilter extends PIXI.Filter {
+    class DotFilter extends PIXI.Filter<{}> {
         constructor(scale?:number, angle?:number);
         angle:number;
         scale:number;
     }
-    class DropShadowFilter extends PIXI.Filter {
+    class DropShadowFilter extends PIXI.Filter<{}> {
         constructor(rotation?:number, distance?:number, blur?:number, color?:number, alpha?:number);
         alpha:number;
         blur:number;
@@ -61,72 +61,72 @@ declare namespace PIXI.filters {
         distance:number;
         rotation:number;
     }
-    class EmbossFilter extends PIXI.Filter {
+    class EmbossFilter extends PIXI.Filter<{}> {
         constructor(strength?:number);
         strength:number;
     }
-    class GlowFilter extends PIXI.Filter {
+    class GlowFilter extends PIXI.Filter<{}> {
         constructor(distance?:number, outerStrength?:number, innerStrength?:number, color?:number, quality?:number);
         color:number;
         distance:number;
         innerStrength:number;
         outerStrength:number;
     }
-    class GodrayFilter extends PIXI.Filter {
+    class GodrayFilter extends PIXI.Filter<{}> {
         constructor(angle?:number, gain?:number, lacunarity?:number, time?:number);
         angle:number;
         gain:number;
         lacunarity:number;
         time:number;
     }
-    class OutlineFilter extends PIXI.Filter {
+    class OutlineFilter extends PIXI.Filter<{}> {
         constructor(thickness?:number, color?:number);
         color:number;
         thickness:number;
     }
-    class MultiColorReplaceFilter extends PIXI.Filter {
+    class MultiColorReplaceFilter extends PIXI.Filter<{}> {
         constructor(replacements:Array<number[]|number[][]>, epsilon?:number, maxColors?:number);
         replacements:Array<number[]|number[][]>;
         epsilon:number;
         readonly maxColors:number;
         refresh():void;
     }
-    class PixelateFilter extends PIXI.Filter {
+    class PixelateFilter extends PIXI.Filter<{}> {
         constructor(size?:PIXI.Point|number[]|number);
         size:PIXI.Point|number[]|number;
     }
-    class RGBSplitFilter extends PIXI.Filter {
+    class RGBSplitFilter extends PIXI.Filter<{}> {
         constructor(red?:PIXI.Point, green?:PIXI.Point, blue?:PIXI.Point);
         red:PIXI.Point;
         green:PIXI.Point;
         blue:PIXI.Point;
     }
-    class ShockwaveFilter extends PIXI.Filter {
+    class ShockwaveFilter extends PIXI.Filter<{}> {
         constructor(center?:PIXI.Point, params?:number[], time?:number);
         center:PIXI.Point;
         params:number[];
         time:number;
     }
-    class SimpleLightmapFilter extends PIXI.Filter {
+    class SimpleLightmapFilter extends PIXI.Filter<{}> {
         constructor(texture:PIXI.Texture, color?:number[]|number);
         alpha:number;
         color:number[]|number;
         texture:PIXI.Texture;
     }
-    class TiltShiftFilter extends PIXI.Filter {
+    class TiltShiftFilter extends PIXI.Filter<{}> {
         constructor(blur?:number, gradientBlur?:number, start?:PIXI.Point, end?:PIXI.Point);
         blur:number;
         end:PIXI.Point;
         gradientBlur:number;
         start:PIXI.Point;
     }
-    class TwistFilter extends PIXI.Filter {
+    class TwistFilter extends PIXI.Filter<{}> {
         constructor(radius?:number, angle?:number, padding?:number);
         angle:number;
         offset:PIXI.Point;
         radius:number;
     }
-    class ZoomBlurFilter extends PIXI.Filter {
+    class ZoomBlurFilter extends PIXI.Filter<{}> {
         constructor(strength?:number, center?:PIXI.Point|number[], innerRadius?:number, radius?:number);
         strength:number;
         center:PIXI.Point|number[];

--- a/filters/advanced-bloom/types.d.ts
+++ b/filters/advanced-bloom/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class AdvancedBloomFilter extends PIXI.Filter {
+    class AdvancedBloomFilter extends PIXI.Filter<{}> {
         constructor(options?: AdvancedBloomOptions);
         constructor(threshold?: number);
         threshold: number;

--- a/filters/ascii/types.d.ts
+++ b/filters/ascii/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class AsciiFilter extends PIXI.Filter {
+    class AsciiFilter extends PIXI.Filter<{}> {
         constructor(size?:number);
         size:number;
     }

--- a/filters/bloom/types.d.ts
+++ b/filters/bloom/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class BloomFilter extends PIXI.Filter {
+    class BloomFilter extends PIXI.Filter<{}> {
         constructor(blur?:number|PIXI.Point|number[], quality?:number, resolution?:number, kernelSize?:number);
         blur:number;
         blurX:number;

--- a/filters/bulge-pinch/types.d.ts
+++ b/filters/bulge-pinch/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class BulgePinchFilter extends PIXI.Filter {
+    class BulgePinchFilter extends PIXI.Filter<{}> {
         constructor(center?:PIXI.Point|number[], radius?:number, strength?:number);
         center:PIXI.Point;
         radius:number;

--- a/filters/color-replace/types.d.ts
+++ b/filters/color-replace/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class ColorReplaceFilter extends PIXI.Filter {
+    class ColorReplaceFilter extends PIXI.Filter<{}> {
         constructor(originalColor?:number|number[], newColor?:number|number[], epsilon?:number);
         epsilon:number;
         originalColor:number|number[];

--- a/filters/convolution/types.d.ts
+++ b/filters/convolution/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class ConvolutionFilter extends PIXI.Filter {
+    class ConvolutionFilter extends PIXI.Filter<{}> {
         constructor(matrix:number[], width:number, height:number);
         height:number;
         width:number;

--- a/filters/cross-hatch/types.d.ts
+++ b/filters/cross-hatch/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class CrossHatchFilter extends PIXI.Filter {
+    class CrossHatchFilter extends PIXI.Filter<{}> {
         constructor();
     }
 }

--- a/filters/dot/types.d.ts
+++ b/filters/dot/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class DotFilter extends PIXI.Filter {
+    class DotFilter extends PIXI.Filter<{}> {
         constructor(scale?:number, angle?:number);
         angle:number;
         scale:number;

--- a/filters/drop-shadow/types.d.ts
+++ b/filters/drop-shadow/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class DropShadowFilter extends PIXI.Filter {
+    class DropShadowFilter extends PIXI.Filter<{}> {
         constructor(rotation?:number, distance?:number, blur?:number, color?:number, alpha?:number);
         alpha:number;
         blur:number;

--- a/filters/emboss/types.d.ts
+++ b/filters/emboss/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class EmbossFilter extends PIXI.Filter {
+    class EmbossFilter extends PIXI.Filter<{}> {
         constructor(strength?:number);
         strength:number;
     }

--- a/filters/glow/types.d.ts
+++ b/filters/glow/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class GlowFilter extends PIXI.Filter {
+    class GlowFilter extends PIXI.Filter<{}> {
         constructor(distance?:number, outerStrength?:number, innerStrength?:number, color?:number, quality?:number);
         color:number;
         distance:number;

--- a/filters/godray/types.d.ts
+++ b/filters/godray/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class GodrayFilter extends PIXI.Filter {
+    class GodrayFilter extends PIXI.Filter<{}> {
         constructor(angle?:number, gain?:number, lacunarity?:number, time?:number);
         angle:number;
         gain:number;

--- a/filters/multi-color-replace/types.d.ts
+++ b/filters/multi-color-replace/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class MultiColorReplaceFilter extends PIXI.Filter {
+    class MultiColorReplaceFilter extends PIXI.Filter<{}> {
         constructor(replacements:Array<number[]|number[][]>, epsilon?:number, maxColors?:number);
         replacements:Array<number[]|number[][]>;
         epsilon:number;

--- a/filters/outline/types.d.ts
+++ b/filters/outline/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class OutlineFilter extends PIXI.Filter {
+    class OutlineFilter extends PIXI.Filter<{}> {
         constructor(thickness?:number, color?:number);
         color:number;
         thickness:number;

--- a/filters/pixelate/types.d.ts
+++ b/filters/pixelate/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class PixelateFilter extends PIXI.Filter {
+    class PixelateFilter extends PIXI.Filter<{}> {
         constructor(size?:PIXI.Point|number[]|number);
         size:PIXI.Point|number[]|number;
     }

--- a/filters/rgb-split/types.d.ts
+++ b/filters/rgb-split/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class RGBSplitFilter extends PIXI.Filter {
+    class RGBSplitFilter extends PIXI.Filter<{}> {
         constructor(red?:PIXI.Point, green?:PIXI.Point, blue?:PIXI.Point);
         red:PIXI.Point;
         green:PIXI.Point;

--- a/filters/shockwave/types.d.ts
+++ b/filters/shockwave/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class ShockwaveFilter extends PIXI.Filter {
+    class ShockwaveFilter extends PIXI.Filter<{}> {
         constructor(center?:PIXI.Point, params?:number[], time?:number);
         center:PIXI.Point;
         params:number[];

--- a/filters/simple-lightmap/types.d.ts
+++ b/filters/simple-lightmap/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class SimpleLightmapFilter extends PIXI.Filter {
+    class SimpleLightmapFilter extends PIXI.Filter<{}> {
         constructor(texture:PIXI.Texture, color?:number[]|number);
         alpha:number;
         color:number[]|number;

--- a/filters/tilt-shift/types.d.ts
+++ b/filters/tilt-shift/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class TiltShiftFilter extends PIXI.Filter {
+    class TiltShiftFilter extends PIXI.Filter<{}> {
         constructor(blur?:number, gradientBlur?:number, start?:PIXI.Point, end?:PIXI.Point);
         blur:number;
         end:PIXI.Point;

--- a/filters/twist/types.d.ts
+++ b/filters/twist/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class TwistFilter extends PIXI.Filter {
+    class TwistFilter extends PIXI.Filter<{}> {
         constructor(radius?:number, angle?:number, padding?:number);
         angle:number;
         offset:PIXI.Point;

--- a/filters/zoom-blur/types.d.ts
+++ b/filters/zoom-blur/types.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    class ZoomBlurFilter extends PIXI.Filter {
+    class ZoomBlurFilter extends PIXI.Filter<{}> {
         constructor(strength?:number, center?:PIXI.Point|number[], innerRadius?:number, radius?:number);
         strength:number;
         center:PIXI.Point|number[];


### PR DESCRIPTION
This fixes compatibility with [pixi.js typings](https://github.com/pixijs/pixi-typescript/blob/v4.x/pixi.js.d.ts#L1290) where Filter requires the uniform data template. 

We have explicitly decided not to document uniforms in **pixi-filters** because we want people to use the API properties instead.

Discovered this when creating [Rollup + TypeScript Example](https://github.com/pixijs/pixi-filters/wiki/Rollup---TypeScript-Example)