### PR TITLE
Don't stop shader , when fish & pond are stopped

### DIFF
--- a/tools/demo/src/DemoApplication.js
+++ b/tools/demo/src/DemoApplication.js
@@ -193,15 +193,15 @@ export default class DemoApplication extends PIXI.Application {
      */
     animate(delta) {
 
-        if (!this.animating) {
-            return;
-        }
-
         this.animateTimer += 0.1 * delta;
 
         const {bounds, animateTimer, overlay} = this;
 
         this.events.emit('animate', delta, animateTimer);
+
+        if (!this.animating) {
+            return;
+        }
 
         // Animate the overlay
         overlay.tilePosition.x = animateTimer * -10;

--- a/tools/demo/src/DemoApplication.js
+++ b/tools/demo/src/DemoApplication.js
@@ -193,7 +193,7 @@ export default class DemoApplication extends PIXI.Application {
      */
     animate(delta) {
 
-        this.animateTimer += 0.1 * delta;
+        this.animateTimer += delta;
 
         const {bounds, animateTimer, overlay} = this;
 
@@ -204,8 +204,8 @@ export default class DemoApplication extends PIXI.Application {
         }
 
         // Animate the overlay
-        overlay.tilePosition.x = animateTimer * -10;
-        overlay.tilePosition.y = animateTimer * -10;
+        overlay.tilePosition.x = animateTimer * -1;
+        overlay.tilePosition.y = animateTimer * -1;
 
         for (let i = 0; i < this.fishes.length; i++) {
 


### PR DESCRIPTION
I add this property for stopping fish & pond only.
The stop  shader & fish & pond , this feature will look like as same as `stop rendering`

So  I hope still run  `this.animateTimer += 0.1 * delta` & ` this.events.emit('animate', delta, animateTimer)`