### PR TITLE
Improve OutlineFilter

### DIFF
--- a/bundle/types.d.ts
+++ b/bundle/types.d.ts
@@ -121,7 +121,7 @@ declare namespace PIXI.filters {
         constructor(thickness?:number, color?:number, quality?:number);
         color:number;
         thickness:number;
-        quality:number;
+        readonly quality:number;
     }
     class PixelateFilter extends PIXI.Filter<{}> {
         constructor(size?:PIXI.Point|number[]|number);

--- a/bundle/types.d.ts
+++ b/bundle/types.d.ts
@@ -118,9 +118,10 @@ declare namespace PIXI.filters {
         vignettingBlur?: number;
     }
     class OutlineFilter extends PIXI.Filter<{}> {
-        constructor(thickness?:number, color?:number);
+        constructor(thickness?:number, color?:number, quality?:number);
         color:number;
         thickness:number;
+        quality:number;
     }
     class PixelateFilter extends PIXI.Filter<{}> {
         constructor(size?:PIXI.Point|number[]|number);

--- a/filters/outline/README.md
+++ b/filters/outline/README.md
@@ -1,6 +1,6 @@
 # OutlineFilter
 
-PixiJS v4 filter to render DisplayObject as ASCII text.
+PixiJS v4 filter to generate & render the outline of DisplayObject.
 
 ## Installation
 

--- a/filters/outline/src/OutlineFilter.js
+++ b/filters/outline/src/OutlineFilter.js
@@ -17,14 +17,18 @@ import fragment from './outline.frag';
  * @example
  *  someSprite.shader = new OutlineFilter(9, 0xFF0000);
  */
+
+const MIN_SAMPLE = 1;
+const MAX_SAMPLE = 100;
+
 export default class OutlineFilter extends PIXI.Filter {
 
     constructor(thickness = 1, color = 0x000000, quality = 0.1) {
+        const sample =  Math.max(quality * MAX_SAMPLE, MIN_SAMPLE);
 
-        // SAMPLE must be `> 2PI / 4`, otherwise the outline can't be closed.
-        const sample = (Math.PI * 2 / Math.max(quality * 100, 4)).toFixed(7);
-
-        super(vertex, fragment.replace(/%SAMPLE%/gi, sample));
+        super(vertex,
+            fragment.replace(/%ANGLE_STEP%/gi, (Math.PI * 2 / sample).toFixed(7))
+        );
 
         this.uniforms.thickness = new Float32Array([0, 0]);
         this.thickness = thickness;

--- a/filters/outline/src/OutlineFilter.js
+++ b/filters/outline/src/OutlineFilter.js
@@ -11,26 +11,31 @@ import fragment from './outline.frag';
  * @extends PIXI.Filter
  * @memberof PIXI.filters
  * @param {number} [thickness=1] The tickness of the outline. Make it 2 times more for resolution 2
- * @param {number} [color=0x000000] The color of the glow.
- * @param {number} [quality=0.1] The quality of the outline. It's from 0.0 to 1.0
+ * @param {number} [color=0x000000] The color of the outline.
+ * @param {number} [quality=0.1] The quality of the outline from `0` to `1`, using a higher quality
+ *        setting will result in slower performance and more accuracy.
  *
  * @example
  *  someSprite.shader = new OutlineFilter(9, 0xFF0000);
  */
-
-const MIN_SAMPLE = 1;
-const MAX_SAMPLE = 100;
-
 export default class OutlineFilter extends PIXI.Filter {
 
     constructor(thickness = 1, color = 0x000000, quality = 0.1) {
-        const sample =  Math.max(quality * MAX_SAMPLE, MIN_SAMPLE);
-
-        super(vertex,
-            fragment.replace(/%ANGLE_STEP%/gi, (Math.PI * 2 / sample).toFixed(7))
+        const samples =  Math.max(
+            quality * OutlineFilter.MAX_SAMPLES,
+            OutlineFilter.MIN_SAMPLES
         );
+        const angleStep = (Math.PI * 2 / samples).toFixed(7);
+
+        super(vertex, fragment.replace(/\$\{angleStep\}/, angleStep));
 
         this.uniforms.thickness = new Float32Array([0, 0]);
+
+        /** 
+         * The thickness of the outline.
+         * @member {number}
+         * @default 1
+         */
         this.thickness = thickness;
 
         this.uniforms.outlineColor = new Float32Array([0, 0, 0, 1]);
@@ -58,6 +63,24 @@ export default class OutlineFilter extends PIXI.Filter {
         PIXI.utils.hex2rgb(value, this.uniforms.outlineColor);
     }
 }
+
+/**
+ * The minimum number of samples for rendering outline.
+ * @static
+ * @member {number} MIN_SAMPLES
+ * @memberof PIXI.filters.OutlineFilter
+ * @default 1
+ */
+OutlineFilter.MIN_SAMPLES = 1;
+
+/**
+ * The maximum number of samples for rendering outline.
+ * @static
+ * @member {number} MAX_SAMPLES
+ * @memberof PIXI.filters.OutlineFilter
+ * @default 100
+ */
+OutlineFilter.MAX_SAMPLES = 100;
 
 // Export to PixiJS namespace
 PIXI.filters.OutlineFilter = OutlineFilter;

--- a/filters/outline/src/outline.frag
+++ b/filters/outline/src/outline.frag
@@ -12,7 +12,7 @@ void main(void) {
     vec4 curColor;
     float maxAlpha = 0.;
     vec2 displaced;
-    for (float angle = 0.; angle < DOUBLE_PI; angle += %ANGLE_STEP% ) {
+    for (float angle = 0.; angle < DOUBLE_PI; angle += ${angleStep} ) {
         displaced.x = vTextureCoord.x + thickness.x * cos(angle);
         displaced.y = vTextureCoord.y + thickness.y * sin(angle);
         curColor = texture2D(uSampler, clamp(displaced, filterClamp.xy, filterClamp.zw));

--- a/filters/outline/src/outline.frag
+++ b/filters/outline/src/outline.frag
@@ -1,21 +1,21 @@
 varying vec2 vTextureCoord;
 uniform sampler2D uSampler;
 
-uniform float thickness;
+uniform vec2 thickness;
 uniform vec4 outlineColor;
 uniform vec4 filterArea;
 uniform vec4 filterClamp;
-vec2 px = vec2(1.0 / filterArea.x, 1.0 / filterArea.y);
+
+#define PI 3.14159265359
 
 void main(void) {
-    const float PI = 3.14159265358979323846264;
     vec4 ownColor = texture2D(uSampler, vTextureCoord);
     vec4 curColor;
     float maxAlpha = 0.;
     vec2 displaced;
-    for (float angle = 0.; angle < PI * 2.; angle += %THICKNESS% ) {
-        displaced.x = vTextureCoord.x + thickness * px.x * cos(angle);
-        displaced.y = vTextureCoord.y + thickness * px.y * sin(angle);
+    for (float angle = 0.; angle < PI * 2.; angle += %SAMPLE% ) {
+        displaced.x = vTextureCoord.x + thickness.x * cos(angle);
+        displaced.y = vTextureCoord.y + thickness.y * sin(angle);
         curColor = texture2D(uSampler, clamp(displaced, filterClamp.xy, filterClamp.zw));
         maxAlpha = max(maxAlpha, curColor.a);
     }

--- a/filters/outline/src/outline.frag
+++ b/filters/outline/src/outline.frag
@@ -6,14 +6,14 @@ uniform vec4 outlineColor;
 uniform vec4 filterArea;
 uniform vec4 filterClamp;
 
-#define PI 3.14159265359
+#define DOUBLE_PI 3.14159265359 * 2.
 
 void main(void) {
     vec4 ownColor = texture2D(uSampler, vTextureCoord);
     vec4 curColor;
     float maxAlpha = 0.;
     vec2 displaced;
-    for (float angle = 0.; angle < PI * 2.; angle += %SAMPLE% ) {
+    for (float angle = 0.; angle < DOUBLE_PI; angle += %ANGLE_STEP% ) {
         displaced.x = vTextureCoord.x + thickness.x * cos(angle);
         displaced.y = vTextureCoord.y + thickness.y * sin(angle);
         curColor = texture2D(uSampler, clamp(displaced, filterClamp.xy, filterClamp.zw));

--- a/filters/outline/src/outline.frag
+++ b/filters/outline/src/outline.frag
@@ -3,7 +3,6 @@ uniform sampler2D uSampler;
 
 uniform vec2 thickness;
 uniform vec4 outlineColor;
-uniform vec4 filterArea;
 uniform vec4 filterClamp;
 
 #define DOUBLE_PI 3.14159265359 * 2.

--- a/filters/outline/types.d.ts
+++ b/filters/outline/types.d.ts
@@ -1,9 +1,10 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
     class OutlineFilter extends PIXI.Filter<{}> {
-        constructor(thickness?:number, color?:number);
+        constructor(thickness?:number, color?:number, quality?:number);
         color:number;
         thickness:number;
+        quality:number;
     }
 }
 

--- a/filters/outline/types.d.ts
+++ b/filters/outline/types.d.ts
@@ -4,7 +4,7 @@ declare namespace PIXI.filters {
         constructor(thickness?:number, color?:number, quality?:number);
         color:number;
         thickness:number;
-        quality:number;
+        readonly quality:number;
     }
 }
 

--- a/tools/demo/src/filters/outline.js
+++ b/tools/demo/src/filters/outline.js
@@ -1,50 +1,14 @@
 export default function() {
-
-    let thickness = window.localStorage.getItem('OutlineFilter.thickness');
-
-    if (thickness === null) {
-        thickness = undefined;
-    }
-    else {
-        thickness = Number(thickness);
-    }
-
-    let quality = window.localStorage.getItem('OutlineFilter.quality');
-
-    if (quality === null) {
-        quality = undefined;
-    }
-    else {
-        quality = Number(quality);
-    }
-
     this.addFilter('OutlineFilter', {
         enabled: false,
         fishOnly: true,
-        args: [thickness, undefined, quality],
+        args: [4, 0x0, 0.25],
         oncreate(folder) {
-            const filter = this;
-
-            filter.padding = filter.thickness + 4;
-
-            folder.add(this, 'thickness', 0, 20).onChange(function(value) {
-                value = Math.round(value);
-                filter.thickness = value;
-                filter.padding = value + 4;
-                window.localStorage.setItem('OutlineFilter.thickness', value);
+            this.padding = this.thickness + 4;
+            folder.add(this, 'thickness', 0, 10).onChange((value) => {
+                this.padding = value + 4;
             });
             folder.addColor(this, 'color');
-
-            folder.add(this, 'quality', 0, 1).onChange(function(value) {
-                value = value.toFixed(2);
-                window.localStorage.setItem('OutlineFilter.quality', value);
-            });
-
-            const tmp = {'tmp': ''};
-            folder.add(tmp, 'tmp');
-
-            const li = folder.__ul.querySelector('li:nth-child(6)');
-            li.innerHTML = ' * `quality` needs to <a style=\'color:#ffffff\' href=\'javascript:window.location.reload()\'>Reload Page</a>';
         }
     });
 }

--- a/tools/demo/src/filters/outline.js
+++ b/tools/demo/src/filters/outline.js
@@ -1,9 +1,50 @@
 export default function() {
+
+    let thickness = window.localStorage.getItem('OutlineFilter.thickness');
+
+    if (thickness === null) {
+        thickness = undefined;
+    }
+    else {
+        thickness = Number(thickness);
+    }
+
+    let quality = window.localStorage.getItem('OutlineFilter.quality');
+
+    if (quality === null) {
+        quality = undefined;
+    }
+    else {
+        quality = Number(quality);
+    }
+
     this.addFilter('OutlineFilter', {
+        enabled: false,
         fishOnly: true,
+        args: [thickness, undefined, quality],
         oncreate(folder) {
-            folder.add(this, 'thickness', 0, 20);
+            const filter = this;
+
+            filter.padding = filter.thickness + 4;
+
+            folder.add(this, 'thickness', 0, 20).onChange(function(value) {
+                value = Math.round(value);
+                filter.thickness = value;
+                filter.padding = value + 4;
+                window.localStorage.setItem('OutlineFilter.thickness', value);
+            });
             folder.addColor(this, 'color');
+
+            folder.add(this, 'quality', 0, 1).onChange(function(value) {
+                value = value.toFixed(2);
+                window.localStorage.setItem('OutlineFilter.quality', value);
+            });
+
+            const tmp = {'tmp': ''};
+            folder.add(tmp, 'tmp');
+
+            const li = folder.__ul.querySelector('li:nth-child(6)');
+            li.innerHTML = ' * `quality` needs to <a style=\'color:#ffffff\' href=\'javascript:window.location.reload()\'>Reload Page</a>';
         }
     });
 }


### PR DESCRIPTION
* add a new argument: `quality`
* use ANGLE_STEP(quality, sample) instead of THICKNESS ( they are different things)
* fix bug about #107 
* optimal performance (just  a little) 
* update outline's demo