### PR TITLE
Fixed bugs of fragment shader in glow-fliter.

### DIFF
--- a/filters/glow/src/glow.frag
+++ b/filters/glow/src/glow.frag
@@ -9,10 +9,10 @@ uniform float innerStrength;
 uniform vec4 glowColor;
 uniform vec4 filterArea;
 uniform vec4 filterClamp;
-vec2 px = vec2(1.0 / filterArea.x, 1.0 / filterArea.y);
+const float PI = 3.14159265358979323846264;
 
 void main(void) {
-    const float PI = 3.14159265358979323846264;
+    vec2 px = vec2(1.0 / filterArea.x, 1.0 / filterArea.y);
     vec4 ownColor = texture2D(uSampler, vTextureCoord);
     vec4 curColor;
     float totalAlpha = 0.0;


### PR DESCRIPTION
Hi.

I used  glow-filter in my project and found the glow-filter could not work in some mobile broswer, those broswers thrown following message:

>S0012: Global variable initializer must be a constant expression.

Then i found in your code you put `const float PI...` in `main` function and let an no-constant variable `px` out of `main` function, it's the reason for this PR.