### PR TITLE
Refactor how global PIXI is used

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,6 @@
         "browser": true
     },
     "globals": {
-        "PIXI": true,
         "Float32Array": true
     },
     "rules": {

--- a/bundle/README.md
+++ b/bundle/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/pixijs/pixi-filters.svg?branch=master)](https://travis-ci.org/pixijs/pixi-filters) [![CDNJS](https://img.shields.io/cdnjs/v/pixi-filters.svg)](https://cdnjs.com/libraries/pixi-filters)
 
-Optional filters that work with PixiJS v4.
+PixiJS v4 optional display filters.
 
 Filters include:
 

--- a/bundle/package.json
+++ b/bundle/package.json
@@ -2,12 +2,13 @@
   "name": "pixi-filters",
   "version": "2.4.1",
   "main": "lib/pixi-filters.cjs.js",
-  "description": "Optional display filters to work with PixiJS",
+  "description": "PixiJS v4 optional display filters",
   "author": "Mat Groves <mat@goodboydigital.com>",
   "contributors": [
     "Ivan Popelyshev <ivan.popelyshev@gmail.com>",
     "Matt Karl <matt@mattkarl.com>",
-    "Chad Engler <chad@pantherdev.com>"
+    "Chad Engler <chad@pantherdev.com>",
+    "finscn <finscn@gmail.com>"
   ],
   "module": "lib/pixi-filters.es.js",
   "bundle": "dist/pixi-filters.js",

--- a/bundle/package.json
+++ b/bundle/package.json
@@ -10,7 +10,7 @@
     "Chad Engler <chad@pantherdev.com>"
   ],
   "module": "lib/pixi-filters.es.js",
-  "browser": "dist/pixi-filters.js",
+  "bundle": "dist/pixi-filters.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",

--- a/bundle/package.json
+++ b/bundle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pixi-filters",
   "version": "2.4.1",
-  "main": "lib/pixi-filters.js",
+  "main": "lib/pixi-filters.cjs.js",
   "description": "Optional display filters to work with PixiJS",
   "author": "Mat Groves <mat@goodboydigital.com>",
   "contributors": [
@@ -10,7 +10,7 @@
     "Chad Engler <chad@pantherdev.com>"
   ],
   "module": "lib/pixi-filters.es.js",
-  "bundle": "dist/pixi-filters.js",
+  "browser": "dist/pixi-filters.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",

--- a/filters/adjustment/README.md
+++ b/filters/adjustment/README.md
@@ -1,6 +1,6 @@
 # AdjustmentFilter
 
-PixiJS v4 filter to adjust gamma/contrast/saturation/brightness.
+PixiJS v4 filter to adjust gamma, contrast, saturation, brightness or color channels.
 
 ## Installation
 

--- a/filters/adjustment/README.md
+++ b/filters/adjustment/README.md
@@ -11,9 +11,10 @@ npm install @pixi/filter-adjustment
 ## Usage
 
 ```js
-import { AdjustmentFilter } from '@pixi/filter-adjustment';
+import {AdjustmentFilter} from '@pixi/filter-adjustment';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new AdjustmentFilter()];
 ```
 

--- a/filters/adjustment/package.json
+++ b/filters/adjustment/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@pixi/filter-adjustment",
   "version": "2.4.0",
-  "main": "lib/filter-adjustment.js",
+  "main": "lib/filter-adjustment.cjs.js",
   "description": "CRT effect filter",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-adjustment.es.js",
+  "browser": "dist/filter-adjustment.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -18,6 +19,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/adjustment/package.json
+++ b/filters/adjustment/package.json
@@ -1,11 +1,10 @@
 {
   "name": "@pixi/filter-adjustment",
   "version": "2.4.0",
-  "main": "lib/filter-adjustment.cjs.js",
+  "main": "lib/filter-adjustment.js",
   "description": "CRT effect filter",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-adjustment.es.js",
-  "browser": "dist/filter-adjustment.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -19,7 +18,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/adjustment/package.json
+++ b/filters/adjustment/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-adjustment",
   "version": "2.4.0",
   "main": "lib/filter-adjustment.js",
-  "description": "CRT effect filter",
+  "description": "PixiJS v4 filter to adjust gamma, contrast, saturation, brightness or color channels",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-adjustment.es.js",
   "types": "types.d.ts",

--- a/filters/adjustment/src/AdjustmentFilter.js
+++ b/filters/adjustment/src/AdjustmentFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './adjustment.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * The ability to adjust gamma, contrast, saturation, brightness, alpha or color-channel shift. This is a faster
@@ -109,6 +110,3 @@ export default class AdjustmentFilter extends PIXI.Filter {
         filterManager.applyFilter(this, input, output, clear);
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.AdjustmentFilter = AdjustmentFilter;

--- a/filters/advanced-bloom/README.md
+++ b/filters/advanced-bloom/README.md
@@ -12,8 +12,9 @@ npm install @pixi/filter-advanced-bloom
 
 ```js
 import {AdvancedBloomFilter} from '@pixi/filter-advanced-bloom';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new AdvancedBloomFilter()];
 ```
 

--- a/filters/advanced-bloom/package.json
+++ b/filters/advanced-bloom/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@pixi/filter-advanced-bloom",
   "version": "2.4.0",
-  "main": "lib/filter-advanced-bloom.cjs.js",
+  "main": "lib/filter-advanced-bloom.js",
   "description": "Display filter render as ASCII text",
   "author": "finscn",
   "contributors": [
     "finscn <finscn@gmail.com>"
   ],
   "module": "lib/filter-advanced-bloom.es.js",
-  "browser": "dist/filter-advanced-bloom.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -22,9 +21,11 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
+  "globals": {
+    "@pixi/filter-kawase-blur": "PIXI.filters"
+  },
   "peerDependencies": {
     "pixi.js": "^4.5.0"
   },

--- a/filters/advanced-bloom/package.json
+++ b/filters/advanced-bloom/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@pixi/filter-advanced-bloom",
   "version": "2.4.0",
-  "main": "lib/filter-advanced-bloom.js",
+  "main": "lib/filter-advanced-bloom.cjs.js",
   "description": "Display filter render as ASCII text",
   "author": "finscn",
   "contributors": [
     "finscn <finscn@gmail.com>"
   ],
   "module": "lib/filter-advanced-bloom.es.js",
+  "browser": "dist/filter-advanced-bloom.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -21,6 +22,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/advanced-bloom/package.json
+++ b/filters/advanced-bloom/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-advanced-bloom",
   "version": "2.4.0",
   "main": "lib/filter-advanced-bloom.js",
-  "description": "Display filter render as ASCII text",
+  "description": "PixiJS v4 filter to render Bloom Filter (with highlight) effect",
   "author": "finscn",
   "contributors": [
     "finscn <finscn@gmail.com>"

--- a/filters/advanced-bloom/src/AdvancedBloomFilter.js
+++ b/filters/advanced-bloom/src/AdvancedBloomFilter.js
@@ -1,6 +1,8 @@
 import ExtractBrightnessFilter from './ExtractBrightnessFilter';
+import {KawaseBlurFilter} from '@pixi/filter-kawase-blur';
 import {vertex} from '@tools/fragments';
 import fragment from './advanced-bloom.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * The AdvancedBloomFilter applies a Bloom Effect to an object. Unlike the normal BloomFilter
@@ -64,13 +66,9 @@ export default class AdvancedBloomFilter extends PIXI.Filter {
 
         this._extractFilter = new ExtractBrightnessFilter(options.threshold);
         this._extractFilter.resolution = resolution;
-
-        const { KawaseBlurFilter } = PIXI.filters;
-
         this._blurFilter = kernels ?
             new KawaseBlurFilter(kernels) :
             new KawaseBlurFilter(blur, quality);
-
         this.pixelSize = pixelSize;
         this.resolution = resolution;
     }
@@ -179,6 +177,3 @@ export default class AdvancedBloomFilter extends PIXI.Filter {
         this._blurFilter.pixelSize = value;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.AdvancedBloomFilter = AdvancedBloomFilter;

--- a/filters/advanced-bloom/src/ExtractBrightnessFilter.js
+++ b/filters/advanced-bloom/src/ExtractBrightnessFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './extract-brightness.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * Internal filter for AdvancedBloomFilter to get brightness.

--- a/filters/ascii/README.md
+++ b/filters/ascii/README.md
@@ -12,8 +12,9 @@ npm install @pixi/filter-ascii
 
 ```js
 import {AsciiFilter} from '@pixi/filter-ascii';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new AsciiFilter()];
 ```
 

--- a/filters/ascii/package.json
+++ b/filters/ascii/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@pixi/filter-ascii",
   "version": "2.4.0",
-  "main": "lib/filter-ascii.cjs.js",
+  "main": "lib/filter-ascii.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-ascii.es.js",
-  "browser": "dist/filter-ascii.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -22,7 +21,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/ascii/package.json
+++ b/filters/ascii/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@pixi/filter-ascii",
   "version": "2.4.0",
-  "main": "lib/filter-ascii.js",
+  "main": "lib/filter-ascii.cjs.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-ascii.es.js",
+  "browser": "dist/filter-ascii.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -21,6 +22,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/ascii/package.json
+++ b/filters/ascii/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-ascii",
   "version": "2.4.0",
   "main": "lib/filter-ascii.js",
-  "description": "Display filter render as ASCII text",
+  "description": "PixiJS v4 filter to render DisplayObject as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"

--- a/filters/ascii/src/AsciiFilter.js
+++ b/filters/ascii/src/AsciiFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './ascii.frag';
+import * as PIXI from 'pixi.js';
 
 // TODO (cengler) - The Y is flipped in this shader for some reason.
 
@@ -36,6 +37,3 @@ export default class AsciiFilter extends PIXI.Filter {
         this.uniforms.pixelSize = value;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.AsciiFilter = AsciiFilter;

--- a/filters/bloom/README.md
+++ b/filters/bloom/README.md
@@ -1,6 +1,6 @@
 # BloomFilter
 
-PixiJS v4 filter to render DisplayObject as ASCII text.
+PixiJS v4 filter to apply a simple bloom effect.
 
 ## Installation
 

--- a/filters/bloom/README.md
+++ b/filters/bloom/README.md
@@ -12,8 +12,9 @@ npm install @pixi/filter-bloom
 
 ```js
 import {BloomFilter} from '@pixi/filter-bloom';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new BloomFilter()];
 ```
 

--- a/filters/bloom/package.json
+++ b/filters/bloom/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-bloom",
   "version": "2.4.0",
   "main": "lib/filter-bloom.js",
-  "description": "Display filter render as ASCII text",
+  "description": "PixiJS v4 filter to apply a simple bloom effect",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"

--- a/filters/bloom/package.json
+++ b/filters/bloom/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@pixi/filter-bloom",
   "version": "2.4.0",
-  "main": "lib/filter-bloom.cjs.js",
+  "main": "lib/filter-bloom.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-bloom.es.js",
-  "browser": "dist/filter-bloom.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -22,7 +21,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/bloom/package.json
+++ b/filters/bloom/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@pixi/filter-bloom",
   "version": "2.4.0",
-  "main": "lib/filter-bloom.js",
+  "main": "lib/filter-bloom.cjs.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-bloom.es.js",
+  "browser": "dist/filter-bloom.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -21,6 +22,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/bloom/src/BloomFilter.js
+++ b/filters/bloom/src/BloomFilter.js
@@ -1,3 +1,5 @@
+import * as PIXI from 'pixi.js';
+
 const {BlurXFilter, BlurYFilter, AlphaFilter} = PIXI.filters;
 
 /**
@@ -91,7 +93,4 @@ export default class BloomFilter extends PIXI.Filter {
         this.blurYFilter.blur = value;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.BloomFilter = BloomFilter;
 

--- a/filters/bulge-pinch/README.md
+++ b/filters/bulge-pinch/README.md
@@ -1,6 +1,6 @@
 # BulgePinchFilter
 
-PixiJS v4 filter to render DisplayObject as ASCII text.
+PixiJS v4 filter to apply a bulge or a pinch effect.
 
 ## Installation
 

--- a/filters/bulge-pinch/README.md
+++ b/filters/bulge-pinch/README.md
@@ -12,8 +12,9 @@ npm install @pixi/filter-bulge-pinch
 
 ```js
 import {BulgePinchFilter} from '@pixi/filter-bulge-pinch';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new BulgePinchFilter()];
 ```
 

--- a/filters/bulge-pinch/package.json
+++ b/filters/bulge-pinch/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@pixi/filter-bulge-pinch",
   "version": "2.4.0",
-  "main": "lib/filter-bulge-pinch.js",
+  "main": "lib/filter-bulge-pinch.cjs.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-bulge-pinch.es.js",
+  "browser": "dist/filter-bulge-pinch.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -21,6 +22,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/bulge-pinch/package.json
+++ b/filters/bulge-pinch/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-bulge-pinch",
   "version": "2.4.0",
   "main": "lib/filter-bulge-pinch.js",
-  "description": "Display filter render as ASCII text",
+  "description": "PixiJS v4 filter to apply a bulge or a pinch effect",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"

--- a/filters/bulge-pinch/package.json
+++ b/filters/bulge-pinch/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@pixi/filter-bulge-pinch",
   "version": "2.4.0",
-  "main": "lib/filter-bulge-pinch.cjs.js",
+  "main": "lib/filter-bulge-pinch.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-bulge-pinch.es.js",
-  "browser": "dist/filter-bulge-pinch.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -22,7 +21,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/bulge-pinch/src/BulgePinchFilter.js
+++ b/filters/bulge-pinch/src/BulgePinchFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './bulgePinch.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * @author Julien CLEREL @JuloxRox
@@ -68,7 +69,4 @@ export default class BulgePinchFilter extends PIXI.Filter {
         this.uniforms.center = value;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.BulgePinchFilter = BulgePinchFilter;
 

--- a/filters/color-replace/README.md
+++ b/filters/color-replace/README.md
@@ -12,8 +12,9 @@ npm install @pixi/filter-color-replace
 
 ```js
 import {ColorReplaceFilter} from '@pixi/filter-color-replace';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new ColorReplaceFilter()];
 ```
 

--- a/filters/color-replace/README.md
+++ b/filters/color-replace/README.md
@@ -1,6 +1,6 @@
 # ColorReplaceFilter
 
-PixiJS v4 filter to render DisplayObject as ASCII text.
+PixiJS v4 filter to replace a single color.
 
 ## Installation
 

--- a/filters/color-replace/package.json
+++ b/filters/color-replace/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-color-replace",
   "version": "2.4.0",
   "main": "lib/filter-color-replace.js",
-  "description": "Display filter render as ASCII text",
+  "description": "PixiJS v4 filter to replace a single color",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"

--- a/filters/color-replace/package.json
+++ b/filters/color-replace/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@pixi/filter-color-replace",
   "version": "2.4.0",
-  "main": "lib/filter-color-replace.js",
+  "main": "lib/filter-color-replace.cjs.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-color-replace.es.js",
+  "browser": "dist/filter-color-replace.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -21,6 +22,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/color-replace/package.json
+++ b/filters/color-replace/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@pixi/filter-color-replace",
   "version": "2.4.0",
-  "main": "lib/filter-color-replace.cjs.js",
+  "main": "lib/filter-color-replace.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-color-replace.es.js",
-  "browser": "dist/filter-color-replace.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -22,7 +21,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/color-replace/src/ColorReplaceFilter.js
+++ b/filters/color-replace/src/ColorReplaceFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './colorReplace.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * ColorReplaceFilter, originally by mishaa, updated by timetocode
@@ -95,7 +96,4 @@ export default class ColorReplaceFilter extends PIXI.Filter {
         return this.uniforms.epsilon;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.ColorReplaceFilter = ColorReplaceFilter;
 

--- a/filters/convolution/README.md
+++ b/filters/convolution/README.md
@@ -12,8 +12,9 @@ npm install @pixi/filter-convolution
 
 ```js
 import {ConvolutionFilter} from '@pixi/filter-convolution';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new ConvolutionFilter()];
 ```
 

--- a/filters/convolution/README.md
+++ b/filters/convolution/README.md
@@ -1,6 +1,6 @@
 # ConvolutionFilter
 
-PixiJS v4 filter to render DisplayObject as ASCII text.
+PixiJS v4 filter to apply a convolution effect.
 
 ## Installation
 

--- a/filters/convolution/package.json
+++ b/filters/convolution/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@pixi/filter-convolution",
   "version": "2.4.0",
-  "main": "lib/filter-convolution.cjs.js",
+  "main": "lib/filter-convolution.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-convolution.es.js",
-  "browser": "dist/filter-convolution.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -22,7 +21,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/convolution/package.json
+++ b/filters/convolution/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@pixi/filter-convolution",
   "version": "2.4.0",
-  "main": "lib/filter-convolution.js",
+  "main": "lib/filter-convolution.cjs.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-convolution.es.js",
+  "browser": "dist/filter-convolution.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -21,6 +22,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/convolution/package.json
+++ b/filters/convolution/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-convolution",
   "version": "2.4.0",
   "main": "lib/filter-convolution.js",
-  "description": "Display filter render as ASCII text",
+  "description": "PixiJS v4 filter to apply a convolution effect",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"

--- a/filters/convolution/src/ConvolutionFilter.js
+++ b/filters/convolution/src/ConvolutionFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './convolution.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * The ConvolutionFilter class applies a matrix convolution filter effect.
@@ -61,7 +62,4 @@ export default class ConvolutionFilter extends PIXI.Filter {
         this.uniforms.texelSize[1] = 1/value;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.ConvolutionFilter = ConvolutionFilter;
 

--- a/filters/cross-hatch/README.md
+++ b/filters/cross-hatch/README.md
@@ -1,6 +1,6 @@
 # CrossHatchFilter
 
-PixiJS v4 filter to render DisplayObject as ASCII text.
+PixiJS v4 filter to apply a cross-hatch black and white effect.
 
 ## Installation
 

--- a/filters/cross-hatch/README.md
+++ b/filters/cross-hatch/README.md
@@ -12,8 +12,9 @@ npm install @pixi/filter-cross-hatch
 
 ```js
 import {CrossHatchFilter} from '@pixi/filter-cross-hatch';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new CrossHatchFilter()];
 ```
 

--- a/filters/cross-hatch/package.json
+++ b/filters/cross-hatch/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@pixi/filter-cross-hatch",
   "version": "2.4.0",
-  "main": "lib/filter-cross-hatch.cjs.js",
+  "main": "lib/filter-cross-hatch.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-cross-hatch.es.js",
-  "browser": "dist/filter-cross-hatch.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -22,7 +21,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/cross-hatch/package.json
+++ b/filters/cross-hatch/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-cross-hatch",
   "version": "2.4.0",
   "main": "lib/filter-cross-hatch.js",
-  "description": "Display filter render as ASCII text",
+  "description": "PixiJS v4 filter to apply a cross-hatch black and white effect",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"

--- a/filters/cross-hatch/package.json
+++ b/filters/cross-hatch/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@pixi/filter-cross-hatch",
   "version": "2.4.0",
-  "main": "lib/filter-cross-hatch.js",
+  "main": "lib/filter-cross-hatch.cjs.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-cross-hatch.es.js",
+  "browser": "dist/filter-cross-hatch.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -21,6 +22,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/cross-hatch/src/CrossHatchFilter.js
+++ b/filters/cross-hatch/src/CrossHatchFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './crosshatch.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * A Cross Hatch effect filter.<br>
@@ -14,6 +15,3 @@ export default class CrossHatchFilter extends PIXI.Filter {
         super(vertex, fragment);
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.CrossHatchFilter = CrossHatchFilter;

--- a/filters/crt/README.md
+++ b/filters/crt/README.md
@@ -1,6 +1,6 @@
 # AdjustBasicFilter
 
-PixiJS v4 filter to render CRT effect.
+PixiJS v4 filter to apply an effect resembling old CRT monitors.
 
 ## Installation
 

--- a/filters/crt/README.md
+++ b/filters/crt/README.md
@@ -11,9 +11,10 @@ npm install @pixi/filter-crt
 ## Usage
 
 ```js
-import { CRTFilter } from '@pixi/filter-crt';
+import {CRTFilter} from '@pixi/filter-crt';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new CRTFilter()];
 ```
 

--- a/filters/crt/package.json
+++ b/filters/crt/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@pixi/filter-crt",
   "version": "2.4.0",
-  "main": "lib/filter-crt.js",
+  "main": "lib/filter-crt.cjs.js",
   "description": "CRT effect filter",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-crt.es.js",
+  "browser": "dist/filter-crt.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -18,6 +19,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/crt/package.json
+++ b/filters/crt/package.json
@@ -1,11 +1,10 @@
 {
   "name": "@pixi/filter-crt",
   "version": "2.4.0",
-  "main": "lib/filter-crt.cjs.js",
+  "main": "lib/filter-crt.js",
   "description": "CRT effect filter",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-crt.es.js",
-  "browser": "dist/filter-crt.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -19,7 +18,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/crt/package.json
+++ b/filters/crt/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-crt",
   "version": "2.4.0",
   "main": "lib/filter-crt.js",
-  "description": "CRT effect filter",
+  "description": "PixiJS v4 filter to apply an effect resembling old CRT monitors",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-crt.es.js",
   "types": "types.d.ts",

--- a/filters/crt/src/CRTFilter.js
+++ b/filters/crt/src/CRTFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './crt.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * The CRTFilter applies a CRT effect to an object.<br>
@@ -190,6 +191,3 @@ export default class CRTFilter extends PIXI.Filter {
         return this.uniforms.vignettingBlur;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.CRTFilter = CRTFilter;

--- a/filters/dot/README.md
+++ b/filters/dot/README.md
@@ -12,8 +12,9 @@ npm install @pixi/filter-ascii
 
 ```js
 import {DropShadowFilter} from '@pixi/filter-ascii';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new DropShadowFilter()];
 ```
 

--- a/filters/dot/README.md
+++ b/filters/dot/README.md
@@ -1,21 +1,21 @@
-# DropShadowFilter
+# DotFilter
 
-PixiJS v4 filter to render DisplayObject as ASCII text.
+PixiJS v4 filter to apply a black and white dot effect.
 
 ## Installation
 
 ```bash
-npm install @pixi/filter-ascii
+npm install @pixi/filter-dot
 ```
 
 ## Usage
 
 ```js
-import {DropShadowFilter} from '@pixi/filter-ascii';
+import {DotFilter} from '@pixi/filter-dot';
 import {Container} from 'pixi.js';
 
 const container = new Container();
-container.filters = [new DropShadowFilter()];
+container.filters = [new DotFilter()];
 ```
 
 ## Documentation

--- a/filters/dot/package.json
+++ b/filters/dot/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@pixi/filter-dot",
   "version": "2.4.0",
-  "main": "lib/filter-dot.js",
+  "main": "lib/filter-dot.cjs.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-dot.es.js",
+  "browser": "dist/filter-dot.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -21,6 +22,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/dot/package.json
+++ b/filters/dot/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-dot",
   "version": "2.4.0",
   "main": "lib/filter-dot.js",
-  "description": "Display filter render as ASCII text",
+  "description": "PixiJS v4 filter to apply a black and white dot effect",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"

--- a/filters/dot/package.json
+++ b/filters/dot/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@pixi/filter-dot",
   "version": "2.4.0",
-  "main": "lib/filter-dot.cjs.js",
+  "main": "lib/filter-dot.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-dot.es.js",
-  "browser": "dist/filter-dot.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -22,7 +21,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/dot/src/DotFilter.js
+++ b/filters/dot/src/DotFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './dot.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * @author Mat Groves http://matgroves.com/ @Doormat23
@@ -49,6 +50,3 @@ export default class DotFilter extends PIXI.Filter {
         this.uniforms.angle = value;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.DotFilter = DotFilter;

--- a/filters/drop-shadow/README.md
+++ b/filters/drop-shadow/README.md
@@ -12,8 +12,9 @@ npm install @pixi/filter-drop-shadow
 
 ```js
 import {DropShadowFilter} from '@pixi/filter-drop-shadow';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new DropShadowFilter()];
 ```
 

--- a/filters/drop-shadow/README.md
+++ b/filters/drop-shadow/README.md
@@ -1,6 +1,6 @@
 # DropShadowFilter
 
-PixiJS v4 filter to generate & render the drop shadow of DisplayObject.
+PixiJS v4 filter to apply a drop shadow effect.
 
 ## Installation
 

--- a/filters/drop-shadow/package.json
+++ b/filters/drop-shadow/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-drop-shadow",
   "version": "2.4.0",
   "main": "lib/filter-drop-shadow.js",
-  "description": "Display filter render as ASCII text",
+  "description": "PixiJS v4 filter to apply a drop shadow effect",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"

--- a/filters/drop-shadow/package.json
+++ b/filters/drop-shadow/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@pixi/filter-drop-shadow",
   "version": "2.4.0",
-  "main": "lib/filter-drop-shadow.cjs.js",
+  "main": "lib/filter-drop-shadow.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-drop-shadow.es.js",
-  "browser": "dist/filter-drop-shadow.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -22,7 +21,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/drop-shadow/package.json
+++ b/filters/drop-shadow/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@pixi/filter-drop-shadow",
   "version": "2.4.0",
-  "main": "lib/filter-drop-shadow.js",
+  "main": "lib/filter-drop-shadow.cjs.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-drop-shadow.es.js",
+  "browser": "dist/filter-drop-shadow.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -21,6 +22,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/drop-shadow/src/DropShadowFilter.js
+++ b/filters/drop-shadow/src/DropShadowFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './dropshadow.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * Drop shadow filter.<br>
@@ -122,6 +123,3 @@ export default class DropShadowFilter extends PIXI.Filter {
         PIXI.utils.hex2rgb(value, this.tintFilter.uniforms.color);
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.DropShadowFilter = DropShadowFilter;

--- a/filters/emboss/README.md
+++ b/filters/emboss/README.md
@@ -1,6 +1,6 @@
 # EmbossFilter
 
-PixiJS v4 filter to render DisplayObject as ASCII text.
+PixiJS v4 filter to apply an emboss effect.
 
 ## Installation
 

--- a/filters/emboss/README.md
+++ b/filters/emboss/README.md
@@ -12,8 +12,9 @@ npm install @pixi/filter-emboss
 
 ```js
 import {EmbossFilter} from '@pixi/filter-emboss';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new EmbossFilter()];
 ```
 

--- a/filters/emboss/package.json
+++ b/filters/emboss/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@pixi/filter-emboss",
   "version": "2.4.0",
-  "main": "lib/filter-emboss.js",
+  "main": "lib/filter-emboss.cjs.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-emboss.es.js",
+  "browser": "dist/filter-emboss.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -21,6 +22,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/emboss/package.json
+++ b/filters/emboss/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@pixi/filter-emboss",
   "version": "2.4.0",
-  "main": "lib/filter-emboss.cjs.js",
+  "main": "lib/filter-emboss.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-emboss.es.js",
-  "browser": "dist/filter-emboss.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -22,7 +21,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/emboss/package.json
+++ b/filters/emboss/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-emboss",
   "version": "2.4.0",
   "main": "lib/filter-emboss.js",
-  "description": "Display filter render as ASCII text",
+  "description": "PixiJS v4 filter to apply an emboss effect",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"

--- a/filters/emboss/src/EmbossFilter.js
+++ b/filters/emboss/src/EmbossFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './emboss.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * An RGB Split Filter.<br>
@@ -28,6 +29,3 @@ export default class EmbossFilter extends PIXI.Filter {
         this.uniforms.strength = value;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.EmbossFilter = EmbossFilter;

--- a/filters/glitch/README.md
+++ b/filters/glitch/README.md
@@ -11,9 +11,10 @@ npm install @pixi/filter-glitch
 ## Usage
 
 ```js
-import { GlitchFilter } from '@pixi/filter-glitch';
+import {GlitchFilter} from '@pixi/filter-glitch';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new GlitchFilter()];
 ```
 

--- a/filters/glitch/README.md
+++ b/filters/glitch/README.md
@@ -1,6 +1,6 @@
 # GlitchFilter
 
-PixiJS v4 filter to render glitch effect.
+PixiJS v4 filter to apply a glitch effect.
 
 ## Installation
 

--- a/filters/glitch/package.json
+++ b/filters/glitch/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@pixi/filter-glitch",
   "version": "2.4.0",
-  "main": "lib/filter-glitch.js",
+  "main": "lib/filter-glitch.cjs.js",
   "description": "Multi Color Replace filter",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-glitch.es.js",
+  "browser": "dist/filter-glitch.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -18,6 +19,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/glitch/package.json
+++ b/filters/glitch/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-glitch",
   "version": "2.4.0",
   "main": "lib/filter-glitch.js",
-  "description": "Multi Color Replace filter",
+  "description": "PixiJS v4 filter to apply a glitch effect",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-glitch.es.js",
   "types": "types.d.ts",

--- a/filters/glitch/package.json
+++ b/filters/glitch/package.json
@@ -1,11 +1,10 @@
 {
   "name": "@pixi/filter-glitch",
   "version": "2.4.0",
-  "main": "lib/filter-glitch.cjs.js",
+  "main": "lib/filter-glitch.js",
   "description": "Multi Color Replace filter",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-glitch.es.js",
-  "browser": "dist/filter-glitch.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -19,7 +18,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/glitch/src/GlitchFilter.js
+++ b/filters/glitch/src/GlitchFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './glitch.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * The GlitchFilter applies a glitch effect to an object.<br>
@@ -428,6 +429,3 @@ GlitchFilter.CLAMP = 3;
  * @readonly
  */
 GlitchFilter.MIRROR = 4;
-
-// Export to PixiJS namespace
-PIXI.filters.GlitchFilter = GlitchFilter;

--- a/filters/glow/README.md
+++ b/filters/glow/README.md
@@ -1,6 +1,6 @@
 # GlowFilter
 
-PixiJS v4 filter to render DisplayObject as ASCII text.
+PixiJS v4 filter to apply a glow effect.
 
 ## Installation
 

--- a/filters/glow/README.md
+++ b/filters/glow/README.md
@@ -12,8 +12,9 @@ npm install @pixi/filter-glow
 
 ```js
 import {GlowFilter} from '@pixi/filter-glow';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new GlowFilter()];
 ```
 

--- a/filters/glow/package.json
+++ b/filters/glow/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@pixi/filter-glow",
   "version": "2.4.1",
-  "main": "lib/filter-glow.js",
+  "main": "lib/filter-glow.cjs.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-glow.es.js",
+  "browser": "dist/filter-glow.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -21,6 +22,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/glow/package.json
+++ b/filters/glow/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@pixi/filter-glow",
   "version": "2.4.1",
-  "main": "lib/filter-glow.cjs.js",
+  "main": "lib/filter-glow.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-glow.es.js",
-  "browser": "dist/filter-glow.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -22,7 +21,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/glow/package.json
+++ b/filters/glow/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-glow",
   "version": "2.4.1",
   "main": "lib/filter-glow.js",
-  "description": "Display filter render as ASCII text",
+  "description": "PixiJS v4 filter to apply a glow effect",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"

--- a/filters/glow/src/GlowFilter.js
+++ b/filters/glow/src/GlowFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './glow.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * GlowFilter, originally by mishaa
@@ -84,6 +85,3 @@ export default class GlowFilter extends PIXI.Filter {
         this.uniforms.innerStrength = value;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.GlowFilter = GlowFilter;

--- a/filters/godray/README.md
+++ b/filters/godray/README.md
@@ -1,6 +1,6 @@
 # GodrayFilter
 
-PixiJS v4 filter for godray effect
+PixiJS v4 filter to apply and animate atmospheric light rays.
 
 ## Installation
 

--- a/filters/godray/README.md
+++ b/filters/godray/README.md
@@ -12,8 +12,9 @@ npm install @pixi/filter-godray
 
 ```js
 import {GodrayFilter} from '@pixi/filter-godray';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new GodrayFilter()];
 ```
 

--- a/filters/godray/package.json
+++ b/filters/godray/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-godray",
   "version": "2.4.0",
   "main": "lib/filter-godray.js",
-  "description": "Display filter gorday",
+  "description": "PixiJS v4 filter to apply and animate atmospheric light rays",
   "author": "Alain Galvan",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>",

--- a/filters/godray/package.json
+++ b/filters/godray/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pixi/filter-godray",
   "version": "2.4.0",
-  "main": "lib/filter-godray.js",
+  "main": "lib/filter-godray.cjs.js",
   "description": "Display filter gorday",
   "author": "Alain Galvan",
   "contributors": [
@@ -9,6 +9,7 @@
     "Ivan Popelyshevl <ivan.popelyshev@gmail.com>"
   ],
   "module": "lib/filter-godray.es.js",
+  "browser": "dist/filter-godray.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -22,6 +23,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/godray/package.json
+++ b/filters/godray/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pixi/filter-godray",
   "version": "2.4.0",
-  "main": "lib/filter-godray.cjs.js",
+  "main": "lib/filter-godray.js",
   "description": "Display filter gorday",
   "author": "Alain Galvan",
   "contributors": [
@@ -9,7 +9,6 @@
     "Ivan Popelyshevl <ivan.popelyshev@gmail.com>"
   ],
   "module": "lib/filter-godray.es.js",
-  "browser": "dist/filter-godray.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -23,7 +22,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/godray/src/GodrayFilter.js
+++ b/filters/godray/src/GodrayFilter.js
@@ -1,6 +1,7 @@
 import {vertex} from '@tools/fragments';
 import perlin from './perlin.frag';
 import fragment from './gorday.frag';
+import * as PIXI from 'pixi.js';
 
 /**
 * GordayFilter, {@link https://codepen.io/alaingalvan originally} by Alain Galvan
@@ -153,7 +154,4 @@ export default class GodrayFilter extends PIXI.Filter {
         this.uniforms.lacunarity = value;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.GodrayFilter = GodrayFilter;
 

--- a/filters/kawase-blur/README.md
+++ b/filters/kawase-blur/README.md
@@ -11,10 +11,11 @@ npm install @pixi/filter-kawase-blur
 ## Usage
 
 ```js
-import { KawaseBlurFilter } from '@pixi/filter-kawase-blur';
+import {KawaseBlurFilter} from '@pixi/filter-kawase-blur';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
-container.filters = [new KawaseBlurFilter([4, 3, 2, 1], [1, 1])];
+const container = new Container();
+container.filters = [new KawaseBlurFilter()];
 ```
 
 ## Documentation

--- a/filters/kawase-blur/README.md
+++ b/filters/kawase-blur/README.md
@@ -1,6 +1,6 @@
 # KawaseBlurFilter
 
-PixiJS v4 filter to render Blur effect with kawase algorithm.
+PixiJS v4 filter to apply an alternative, fast blur effect to Gaussian.
 
 ## Installation
 

--- a/filters/kawase-blur/package.json
+++ b/filters/kawase-blur/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@pixi/filter-kawase-blur",
   "version": "2.4.0",
-  "main": "lib/filter-kawase-blur.js",
+  "main": "lib/filter-kawase-blur.cjs.js",
   "description": "Kawase Blur filter",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-kawase-blur.es.js",
+  "browser": "dist/filter-kawase-blur.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -18,6 +19,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/kawase-blur/package.json
+++ b/filters/kawase-blur/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-kawase-blur",
   "version": "2.4.0",
   "main": "lib/filter-kawase-blur.js",
-  "description": "Kawase Blur filter",
+  "description": "PixiJS v4 filter to apply an alternative, fast blur effect to Gaussian",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-kawase-blur.es.js",
   "types": "types.d.ts",

--- a/filters/kawase-blur/package.json
+++ b/filters/kawase-blur/package.json
@@ -1,11 +1,10 @@
 {
   "name": "@pixi/filter-kawase-blur",
   "version": "2.4.0",
-  "main": "lib/filter-kawase-blur.cjs.js",
+  "main": "lib/filter-kawase-blur.js",
   "description": "Kawase Blur filter",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-kawase-blur.es.js",
-  "browser": "dist/filter-kawase-blur.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -19,7 +18,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/kawase-blur/src/KawaseBlurFilter.js
+++ b/filters/kawase-blur/src/KawaseBlurFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './kawase-blur.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * A much faster blur than Gaussian blur, but more complicated to use.<br>
@@ -177,6 +178,3 @@ export default class KawaseBlurFilter extends PIXI.Filter {
         this._generateKernels();
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.KawaseBlurFilter = KawaseBlurFilter;

--- a/filters/motion-blur/README.md
+++ b/filters/motion-blur/README.md
@@ -11,9 +11,10 @@ npm install @pixi/filter-motion-blur
 ## Usage
 
 ```js
-import { MotionBlurFilter } from '@pixi/filter-motion-blur';
+import {MotionBlurFilter} from '@pixi/filter-motion-blur';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new MotionBlurFilter([1,2], 9)];
 ```
 

--- a/filters/motion-blur/README.md
+++ b/filters/motion-blur/README.md
@@ -1,6 +1,6 @@
 # MotionBlurFilter
 
-PixiJS v4 filter to render Motion Blur effect.
+PixiJS v4 filter to apply a directional blur effect.
 
 ## Installation
 

--- a/filters/motion-blur/package.json
+++ b/filters/motion-blur/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@pixi/filter-motion-blur",
   "version": "2.4.0",
-  "main": "lib/filter-motion-blur.js",
+  "main": "lib/filter-motion-blur.cjs.js",
   "description": "Multi Color Replace filter",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-motion-blur.es.js",
+  "browser": "dist/filter-motion-blur.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -18,6 +19,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/motion-blur/package.json
+++ b/filters/motion-blur/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-motion-blur",
   "version": "2.4.0",
   "main": "lib/filter-motion-blur.js",
-  "description": "Multi Color Replace filter",
+  "description": "PixiJS v4 filter to apply a directional blur effect",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-motion-blur.es.js",
   "types": "types.d.ts",

--- a/filters/motion-blur/package.json
+++ b/filters/motion-blur/package.json
@@ -1,11 +1,10 @@
 {
   "name": "@pixi/filter-motion-blur",
   "version": "2.4.0",
-  "main": "lib/filter-motion-blur.cjs.js",
+  "main": "lib/filter-motion-blur.js",
   "description": "Multi Color Replace filter",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-motion-blur.es.js",
-  "browser": "dist/filter-motion-blur.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -19,7 +18,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/motion-blur/src/MotionBlurFilter.js
+++ b/filters/motion-blur/src/MotionBlurFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './motion-blur.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * The MotionBlurFilter applies a Motion blur to an object.<br>
@@ -78,6 +79,3 @@ export default class MotionBlurFilter extends PIXI.Filter {
         return this.uniforms.uOffset;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.MotionBlurFilter = MotionBlurFilter;

--- a/filters/multi-color-replace/README.md
+++ b/filters/multi-color-replace/README.md
@@ -1,6 +1,6 @@
 # MultiColorReplaceFilter
 
-PixiJS v4 filter to render Multi Color Replace effect.
+PixiJS v4 filter to dynamically replace multiple colors.
 
 ## Installation
 

--- a/filters/multi-color-replace/README.md
+++ b/filters/multi-color-replace/README.md
@@ -11,9 +11,10 @@ npm install @pixi/filter-multi-color-replace
 ## Usage
 
 ```js
-import { MultiColorReplaceFilter } from '@pixi/filter-multi-color-replace';
+import {MultiColorReplaceFilter} from '@pixi/filter-multi-color-replace';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new MultiColorReplaceFilter([0x0000FF, 0x00FF00], [0xFF0000, 0xFFFF00], 0.2)];
 ```
 

--- a/filters/multi-color-replace/README.md
+++ b/filters/multi-color-replace/README.md
@@ -15,7 +15,13 @@ import {MultiColorReplaceFilter} from '@pixi/filter-multi-color-replace';
 import {Container} from 'pixi.js';
 
 const container = new Container();
-container.filters = [new MultiColorReplaceFilter([0x0000FF, 0x00FF00], [0xFF0000, 0xFFFF00], 0.2)];
+container.filters = [
+    new MultiColorReplaceFilter(
+        [0x0000FF, 0x00FF00],
+        [0xFF0000, 0xFFFF00],
+        0.2
+    )
+];
 ```
 
 ## Documentation

--- a/filters/multi-color-replace/package.json
+++ b/filters/multi-color-replace/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@pixi/filter-multi-color-replace",
   "version": "2.4.0",
-  "main": "lib/filter-multi-color-replace.cjs.js",
+  "main": "lib/filter-multi-color-replace.js",
   "description": "Multi Color Replace filter",
   "author": "finscn",
   "contributors": [
     "finscn <finscn@gmail.com>"
   ],
   "module": "lib/filter-multi-color-replace.es.js",
-  "browser": "dist/filter-multi-color-replace.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -22,7 +21,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/multi-color-replace/package.json
+++ b/filters/multi-color-replace/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-multi-color-replace",
   "version": "2.4.0",
   "main": "lib/filter-multi-color-replace.js",
-  "description": "Multi Color Replace filter",
+  "description": "PixiJS v4 filter to dynamically replace multiple colors",
   "author": "finscn",
   "contributors": [
     "finscn <finscn@gmail.com>"

--- a/filters/multi-color-replace/package.json
+++ b/filters/multi-color-replace/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@pixi/filter-multi-color-replace",
   "version": "2.4.0",
-  "main": "lib/filter-multi-color-replace.js",
+  "main": "lib/filter-multi-color-replace.cjs.js",
   "description": "Multi Color Replace filter",
   "author": "finscn",
   "contributors": [
     "finscn <finscn@gmail.com>"
   ],
   "module": "lib/filter-multi-color-replace.es.js",
+  "browser": "dist/filter-multi-color-replace.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -21,6 +22,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/multi-color-replace/src/MultiColorReplaceFilter.js
+++ b/filters/multi-color-replace/src/MultiColorReplaceFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './multi-color-replace.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * Filter for replacing a color with another color. Similar to ColorReplaceFilter, but support multiple
@@ -135,6 +136,3 @@ export default class MultiColorReplaceFilter extends PIXI.Filter {
         return this.uniforms.epsilon;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.MultiColorReplaceFilter = MultiColorReplaceFilter;

--- a/filters/old-film/README.md
+++ b/filters/old-film/README.md
@@ -1,6 +1,6 @@
 # OldFilmFilter
 
-PixiJS v4 filter to render Old Film effect.
+PixiJS v4 filter to apply an old film effect with grain and scratches.
 
 ## Installation
 

--- a/filters/old-film/README.md
+++ b/filters/old-film/README.md
@@ -11,9 +11,10 @@ npm install @pixi/filter-old-film
 ## Usage
 
 ```js
-import { OldFilmFilter } from '@pixi/filter-old-film';
+import {OldFilmFilter} from '@pixi/filter-old-film';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new OldFilmFilter()];
 ```
 

--- a/filters/old-film/package.json
+++ b/filters/old-film/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@pixi/filter-old-film",
   "version": "2.4.0",
-  "main": "lib/filter-old-film.js",
+  "main": "lib/filter-old-film.cjs.js",
   "description": "Old Film effect filter",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-old-film.es.js",
+  "browser": "dist/filter-old-film.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -18,6 +19,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/old-film/package.json
+++ b/filters/old-film/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-old-film",
   "version": "2.4.0",
   "main": "lib/filter-old-film.js",
-  "description": "Old Film effect filter",
+  "description": "PixiJS v4 filter to apply an old film effect with grain and scratches",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-old-film.es.js",
   "types": "types.d.ts",

--- a/filters/old-film/package.json
+++ b/filters/old-film/package.json
@@ -1,11 +1,10 @@
 {
   "name": "@pixi/filter-old-film",
   "version": "2.4.0",
-  "main": "lib/filter-old-film.cjs.js",
+  "main": "lib/filter-old-film.js",
   "description": "Old Film effect filter",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-old-film.es.js",
-  "browser": "dist/filter-old-film.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -19,7 +18,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/old-film/src/OldFilmFilter.js
+++ b/filters/old-film/src/OldFilmFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './old-film.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * The OldFilmFilter applies a Old film effect to an object.<br>
@@ -199,6 +200,3 @@ export default class OldFilmFilter extends PIXI.Filter {
         return this.uniforms.vignettingBlur;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.OldFilmFilter = OldFilmFilter;

--- a/filters/outline/README.md
+++ b/filters/outline/README.md
@@ -12,8 +12,9 @@ npm install @pixi/filter-outline
 
 ```js
 import {OutlineFilter} from '@pixi/filter-outline';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new OutlineFilter()];
 ```
 

--- a/filters/outline/README.md
+++ b/filters/outline/README.md
@@ -1,6 +1,6 @@
 # OutlineFilter
 
-PixiJS v4 filter to generate & render the outline of DisplayObject.
+PixiJS v4 filter to apply an outline/stroke effect.
 
 ## Installation
 

--- a/filters/outline/package.json
+++ b/filters/outline/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@pixi/filter-outline",
   "version": "2.4.1",
-  "main": "lib/filter-outline.cjs.js",
+  "main": "lib/filter-outline.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-outline.es.js",
-  "browser": "dist/filter-outline.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -22,7 +21,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/outline/package.json
+++ b/filters/outline/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-outline",
   "version": "2.4.1",
   "main": "lib/filter-outline.js",
-  "description": "Display filter render as ASCII text",
+  "description": "PixiJS v4 filter to apply an outline/stroke effect",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"

--- a/filters/outline/package.json
+++ b/filters/outline/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@pixi/filter-outline",
   "version": "2.4.1",
-  "main": "lib/filter-outline.js",
+  "main": "lib/filter-outline.cjs.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-outline.es.js",
+  "browser": "dist/filter-outline.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -21,6 +22,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/outline/src/OutlineFilter.js
+++ b/filters/outline/src/OutlineFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './outline.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * OutlineFilter, originally by mishaa
@@ -81,6 +82,3 @@ OutlineFilter.MIN_SAMPLES = 1;
  * @default 100
  */
 OutlineFilter.MAX_SAMPLES = 100;
-
-// Export to PixiJS namespace
-PIXI.filters.OutlineFilter = OutlineFilter;

--- a/filters/pixelate/README.md
+++ b/filters/pixelate/README.md
@@ -1,6 +1,6 @@
 # PixelateFilter
 
-PixiJS v4 filter to render DisplayObject as ASCII text.
+PixiJS v4 filter to apply a pixelation effect.
 
 ## Installation
 

--- a/filters/pixelate/README.md
+++ b/filters/pixelate/README.md
@@ -12,8 +12,9 @@ npm install @pixi/filter-pixelate
 
 ```js
 import {PixelateFilter} from '@pixi/filter-pixelate';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new PixelateFilter()];
 ```
 

--- a/filters/pixelate/package.json
+++ b/filters/pixelate/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@pixi/filter-pixelate",
   "version": "2.4.0",
-  "main": "lib/filter-pixelate.cjs.js",
+  "main": "lib/filter-pixelate.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-pixelate.es.js",
-  "browser": "dist/filter-pixelate.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -22,7 +21,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/pixelate/package.json
+++ b/filters/pixelate/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-pixelate",
   "version": "2.4.0",
   "main": "lib/filter-pixelate.js",
-  "description": "Display filter render as ASCII text",
+  "description": "PixiJS v4 filter to apply a pixelation effect",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"

--- a/filters/pixelate/package.json
+++ b/filters/pixelate/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@pixi/filter-pixelate",
   "version": "2.4.0",
-  "main": "lib/filter-pixelate.js",
+  "main": "lib/filter-pixelate.cjs.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-pixelate.es.js",
+  "browser": "dist/filter-pixelate.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -21,6 +22,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/pixelate/src/PixelateFilter.js
+++ b/filters/pixelate/src/PixelateFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './pixelate.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * This filter applies a pixelate effect making display objects appear 'blocky'.<br>
@@ -34,6 +35,3 @@ export default class PixelateFilter extends PIXI.Filter {
         this.uniforms.size = value;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.PixelateFilter = PixelateFilter;

--- a/filters/radial-blur/README.md
+++ b/filters/radial-blur/README.md
@@ -11,9 +11,10 @@ npm install @pixi/filter-radial-blur
 ## Usage
 
 ```js
-import { RadialBlurFilter } from '@pixi/filter-radial-blur';
+import {RadialBlurFilter} from '@pixi/filter-radial-blur';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new RadialBlurFilter(60, 9)];
 ```
 

--- a/filters/radial-blur/README.md
+++ b/filters/radial-blur/README.md
@@ -1,6 +1,6 @@
 # RadialBlurFilter
 
-PixiJS v4 filter to render Radial Blur effect.
+PixiJS v4 filter to apply a radial blur effect.
 
 ## Installation
 

--- a/filters/radial-blur/package.json
+++ b/filters/radial-blur/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-radial-blur",
   "version": "2.4.0",
   "main": "lib/filter-radial-blur.js",
-  "description": "Multi Color Replace filter",
+  "description": "PixiJS v4 filter to apply a radial blur effect",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-radial-blur.es.js",
   "types": "types.d.ts",

--- a/filters/radial-blur/package.json
+++ b/filters/radial-blur/package.json
@@ -1,11 +1,10 @@
 {
   "name": "@pixi/filter-radial-blur",
   "version": "2.4.0",
-  "main": "lib/filter-radial-blur.cjs.js",
+  "main": "lib/filter-radial-blur.js",
   "description": "Multi Color Replace filter",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-radial-blur.es.js",
-  "browser": "dist/filter-radial-blur.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -19,7 +18,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/radial-blur/package.json
+++ b/filters/radial-blur/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@pixi/filter-radial-blur",
   "version": "2.4.0",
-  "main": "lib/filter-radial-blur.js",
+  "main": "lib/filter-radial-blur.cjs.js",
   "description": "Multi Color Replace filter",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-radial-blur.es.js",
+  "browser": "dist/filter-radial-blur.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -18,6 +19,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/radial-blur/src/RadialBlurFilter.js
+++ b/filters/radial-blur/src/RadialBlurFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './radial-blur.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * The RadialBlurFilter applies a Motion blur to an object.<br>
@@ -79,6 +80,3 @@ export default class RadialBlurFilter extends PIXI.Filter {
         this.uniforms.uRadius = value;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.RadialBlurFilter = RadialBlurFilter;

--- a/filters/reflection/README.md
+++ b/filters/reflection/README.md
@@ -12,8 +12,9 @@ npm install @pixi/filter-reflection
 
 ```js
 import { Reflection } from '@pixi/filter-reflection';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new Reflection()];
 ```
 

--- a/filters/reflection/README.md
+++ b/filters/reflection/README.md
@@ -1,6 +1,6 @@
 # AdjustBasicFilter
 
-PixiJS v4 filter to render Reflection effect.
+PixiJS v4 filter to apply reflection and wave effect.
 
 ## Installation
 

--- a/filters/reflection/README.md
+++ b/filters/reflection/README.md
@@ -11,11 +11,11 @@ npm install @pixi/filter-reflection
 ## Usage
 
 ```js
-import { Reflection } from '@pixi/filter-reflection';
+import {ReflectionFilter} from '@pixi/filter-reflection';
 import {Container} from 'pixi.js';
 
 const container = new Container();
-container.filters = [new Reflection()];
+container.filters = [new ReflectionFilter()];
 ```
 
 ## Documentation

--- a/filters/reflection/package.json
+++ b/filters/reflection/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-reflection",
   "version": "2.4.0",
   "main": "lib/filter-reflection.js",
-  "description": "Reflection effect filter",
+  "description": "PixiJS v4 filter to apply reflection and wave effect",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-reflection.es.js",
   "types": "types.d.ts",

--- a/filters/reflection/package.json
+++ b/filters/reflection/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@pixi/filter-reflection",
   "version": "2.4.0",
-  "main": "lib/filter-reflection.js",
+  "main": "lib/filter-reflection.cjs.js",
   "description": "Reflection effect filter",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-reflection.es.js",
+  "browser": "dist/filter-reflection.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -18,6 +19,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/reflection/package.json
+++ b/filters/reflection/package.json
@@ -1,11 +1,10 @@
 {
   "name": "@pixi/filter-reflection",
   "version": "2.4.0",
-  "main": "lib/filter-reflection.cjs.js",
+  "main": "lib/filter-reflection.js",
   "description": "Reflection effect filter",
   "author": "finscn <finscn@gmail.com>",
   "module": "lib/filter-reflection.es.js",
-  "browser": "dist/filter-reflection.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -19,7 +18,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/reflection/src/ReflectionFilter.js
+++ b/filters/reflection/src/ReflectionFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './reflection.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * Applies a reflection effect to simulate the reflection on water with waves.<br>
@@ -119,6 +120,3 @@ export default class ReflectionFilter extends PIXI.Filter {
         return this.uniforms.alpha;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.ReflectionFilter = ReflectionFilter;

--- a/filters/rgb-split/README.md
+++ b/filters/rgb-split/README.md
@@ -12,8 +12,9 @@ npm install @pixi/filter-rgb-split
 
 ```js
 import {RGBSplitFilter} from '@pixi/filter-rgb-split';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new RGBSplitFilter()];
 ```
 

--- a/filters/rgb-split/README.md
+++ b/filters/rgb-split/README.md
@@ -1,6 +1,6 @@
 # RGBSplitFilter
 
-PixiJS v4 filter to render DisplayObject as rgb-split text.
+PixiJS v4 filter to split and shift red, green or blue channels.
 
 ## Installation
 

--- a/filters/rgb-split/package.json
+++ b/filters/rgb-split/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@pixi/filter-rgb-split",
   "version": "2.4.0",
-  "main": "lib/filter-rgb-split.js",
+  "main": "lib/filter-rgb-split.cjs.js",
   "description": "Display filter render as rgb-split text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-rgb-split.es.js",
+  "browser": "dist/filter-rgb-split.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -21,6 +22,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/rgb-split/package.json
+++ b/filters/rgb-split/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@pixi/filter-rgb-split",
   "version": "2.4.0",
-  "main": "lib/filter-rgb-split.cjs.js",
+  "main": "lib/filter-rgb-split.js",
   "description": "Display filter render as rgb-split text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-rgb-split.es.js",
-  "browser": "dist/filter-rgb-split.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -22,7 +21,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/rgb-split/package.json
+++ b/filters/rgb-split/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-rgb-split",
   "version": "2.4.0",
   "main": "lib/filter-rgb-split.js",
-  "description": "Display filter render as rgb-split text",
+  "description": "PixiJS v4 filter to split and shift red, green or blue channels",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"

--- a/filters/rgb-split/src/RGBSplitFilter.js
+++ b/filters/rgb-split/src/RGBSplitFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './rgb-split.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * An RGB Split Filter.<br>
@@ -56,6 +57,3 @@ export default class RGBSplitFilter extends PIXI.Filter {
         this.uniforms.blue = value;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.RGBSplitFilter = RGBSplitFilter;

--- a/filters/shockwave/README.md
+++ b/filters/shockwave/README.md
@@ -1,6 +1,6 @@
 # ShockwaveFilter
 
-PixiJS v4 filter to render DisplayObject as ASCII text.
+PixiJS v4 filter to apply a shockwave-type effect.
 
 ## Installation
 

--- a/filters/shockwave/README.md
+++ b/filters/shockwave/README.md
@@ -12,8 +12,9 @@ npm install @pixi/filter-ascii
 
 ```js
 import {ShockwaveFilter} from '@pixi/filter-ascii';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new ShockwaveFilter()];
 ```
 

--- a/filters/shockwave/package.json
+++ b/filters/shockwave/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@pixi/filter-shockwave",
   "version": "2.4.0",
-  "main": "lib/filter-shockwave.js",
+  "main": "lib/filter-shockwave.cjs.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-shockwave.es.js",
+  "browser": "dist/filter-shockwave.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -21,6 +22,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/shockwave/package.json
+++ b/filters/shockwave/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@pixi/filter-shockwave",
   "version": "2.4.0",
-  "main": "lib/filter-shockwave.cjs.js",
+  "main": "lib/filter-shockwave.js",
   "description": "Display filter render as ASCII text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-shockwave.es.js",
-  "browser": "dist/filter-shockwave.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -22,7 +21,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/shockwave/package.json
+++ b/filters/shockwave/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-shockwave",
   "version": "2.4.0",
   "main": "lib/filter-shockwave.js",
-  "description": "Display filter render as ASCII text",
+  "description": "PixiJS v4 filter to apply a shockwave-type effect",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"

--- a/filters/shockwave/src/ShockwaveFilter.js
+++ b/filters/shockwave/src/ShockwaveFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './shockwave.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * The ShockwaveFilter class lets you apply a shockwave effect.<br>
@@ -144,7 +145,4 @@ export default class ShockwaveFilter extends PIXI.Filter {
         this.uniforms.radius = value;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.ShockwaveFilter = ShockwaveFilter;
 

--- a/filters/simple-lightmap/README.md
+++ b/filters/simple-lightmap/README.md
@@ -12,8 +12,9 @@ npm install @pixi/filter-simple-lightmap
 
 ```js
 import {SimpleLightmapFilter} from '@pixi/filter-simple-lightmap';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new SimpleLightmapFilter(texture, [0, 0, 0, 0.5])];
 ```
 

--- a/filters/simple-lightmap/README.md
+++ b/filters/simple-lightmap/README.md
@@ -1,6 +1,6 @@
-# simple-lightmapFilter
+# SimpleLightmapFilter
 
-PixiJS v4 filter to render DisplayObject as simple-lightmap text.
+PixiJS v4 filter to create a light-map from a texture.
 
 ## Installation
 

--- a/filters/simple-lightmap/package.json
+++ b/filters/simple-lightmap/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@pixi/filter-simple-lightmap",
   "version": "2.4.0",
-  "main": "lib/filter-simple-lightmap.js",
+  "main": "lib/filter-simple-lightmap.cjs.js",
   "description": "Display filter render as simple-lightmap text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-simple-lightmap.es.js",
+  "browser": "dist/filter-simple-lightmap.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -21,6 +22,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/simple-lightmap/package.json
+++ b/filters/simple-lightmap/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@pixi/filter-simple-lightmap",
   "version": "2.4.0",
-  "main": "lib/filter-simple-lightmap.cjs.js",
+  "main": "lib/filter-simple-lightmap.js",
   "description": "Display filter render as simple-lightmap text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-simple-lightmap.es.js",
-  "browser": "dist/filter-simple-lightmap.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -22,7 +21,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/simple-lightmap/package.json
+++ b/filters/simple-lightmap/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-simple-lightmap",
   "version": "2.4.0",
   "main": "lib/filter-simple-lightmap.js",
-  "description": "Display filter render as simple-lightmap text",
+  "description": "PixiJS v4 filter to create a light-map from a texture",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"

--- a/filters/simple-lightmap/src/SimpleLightmapFilter.js
+++ b/filters/simple-lightmap/src/SimpleLightmapFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './simpleLightmap.frag';
+import * as PIXI from 'pixi.js';
 
 /**
 * SimpleLightmap, originally by Oza94
@@ -93,7 +94,4 @@ export default class SimpleLightmapFilter extends PIXI.Filter {
         this.uniforms.ambientColor[3] = value;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.SimpleLightmapFilter = SimpleLightmapFilter;
 

--- a/filters/tilt-shift/README.md
+++ b/filters/tilt-shift/README.md
@@ -12,8 +12,9 @@ npm install @pixi/filter-tilt-shift
 
 ```js
 import {tilt-shiftFilter} from '@pixi/filter-tilt-shift';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new tilt-shiftFilter()];
 ```
 

--- a/filters/tilt-shift/README.md
+++ b/filters/tilt-shift/README.md
@@ -1,6 +1,6 @@
-# tilt-shiftFilter
+# TiltShiftFilter
 
-PixiJS v4 filter to render DisplayObject as tilt-shift text.
+PixiJS v4 filter to render a tilt-shift-like camera effect.
 
 ## Installation
 
@@ -11,11 +11,11 @@ npm install @pixi/filter-tilt-shift
 ## Usage
 
 ```js
-import {tilt-shiftFilter} from '@pixi/filter-tilt-shift';
+import {TiltShiftFilter} from '@pixi/filter-tilt-shift';
 import {Container} from 'pixi.js';
 
 const container = new Container();
-container.filters = [new tilt-shiftFilter()];
+container.filters = [new TiltShiftFilter()];
 ```
 
 ## Documentation

--- a/filters/tilt-shift/package.json
+++ b/filters/tilt-shift/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@pixi/filter-tilt-shift",
   "version": "2.4.0",
-  "main": "lib/filter-tilt-shift.cjs.js",
+  "main": "lib/filter-tilt-shift.js",
   "description": "Display filter render as tilt-shift text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-tilt-shift.es.js",
-  "browser": "dist/filter-tilt-shift.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -22,7 +21,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/tilt-shift/package.json
+++ b/filters/tilt-shift/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@pixi/filter-tilt-shift",
   "version": "2.4.0",
-  "main": "lib/filter-tilt-shift.js",
+  "main": "lib/filter-tilt-shift.cjs.js",
   "description": "Display filter render as tilt-shift text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-tilt-shift.es.js",
+  "browser": "dist/filter-tilt-shift.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -21,6 +22,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/tilt-shift/package.json
+++ b/filters/tilt-shift/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-tilt-shift",
   "version": "2.4.0",
   "main": "lib/filter-tilt-shift.js",
-  "description": "Display filter render as tilt-shift text",
+  "description": "PixiJS v4 filter to render a tilt-shift-like camera effect",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"

--- a/filters/tilt-shift/src/TiltShiftAxisFilter.js
+++ b/filters/tilt-shift/src/TiltShiftAxisFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './tilt-shift.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * @author Vico @vicocotea
@@ -91,7 +92,4 @@ export default class TiltShiftAxisFilter extends PIXI.Filter {
         this.updateDelta();
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.TiltShiftAxisFilter = TiltShiftAxisFilter;
 

--- a/filters/tilt-shift/src/TiltShiftFilter.js
+++ b/filters/tilt-shift/src/TiltShiftFilter.js
@@ -1,5 +1,6 @@
 import TiltShiftXFilter from './TiltShiftXFilter';
 import TiltShiftYFilter from './TiltShiftYFilter';
+import * as PIXI from 'pixi.js';
 
 /**
  * @author Vico @vicocotea
@@ -81,6 +82,3 @@ export default class TiltShiftFilter extends PIXI.Filter {
         this.tiltShiftXFilter.end = this.tiltShiftYFilter.end = value;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.TiltShiftFilter = TiltShiftFilter;

--- a/filters/tilt-shift/src/TiltShiftXFilter.js
+++ b/filters/tilt-shift/src/TiltShiftXFilter.js
@@ -25,6 +25,3 @@ export default class TiltShiftXFilter extends TiltShiftAxisFilter {
         this.uniforms.delta.y = dy / d;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.TiltShiftXFilter = TiltShiftXFilter;

--- a/filters/tilt-shift/src/TiltShiftYFilter.js
+++ b/filters/tilt-shift/src/TiltShiftYFilter.js
@@ -25,6 +25,3 @@ export default class TiltShiftYFilter extends TiltShiftAxisFilter {
         this.uniforms.delta.y = dx / d;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.TiltShiftYFilter = TiltShiftYFilter;

--- a/filters/twist/README.md
+++ b/filters/twist/README.md
@@ -1,6 +1,6 @@
-# twistFilter
+# TwistFilter
 
-PixiJS v4 filter to render DisplayObject as twist text.
+PixiJS v4 filter to apply a twist effect to a DisplayObject.
 
 ## Installation
 
@@ -11,11 +11,11 @@ npm install @pixi/filter-twist
 ## Usage
 
 ```js
-import {twistFilter} from '@pixi/filter-twist';
+import {TwistFilter} from '@pixi/filter-twist';
 import {Container} from 'pixi.js';
 
 const container = new Container();
-container.filters = [new twistFilter()];
+container.filters = [new TwistFilter()];
 ```
 
 ## Documentation

--- a/filters/twist/README.md
+++ b/filters/twist/README.md
@@ -12,8 +12,9 @@ npm install @pixi/filter-twist
 
 ```js
 import {twistFilter} from '@pixi/filter-twist';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new twistFilter()];
 ```
 

--- a/filters/twist/package.json
+++ b/filters/twist/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@pixi/filter-twist",
   "version": "2.4.0",
-  "main": "lib/filter-twist.cjs.js",
+  "main": "lib/filter-twist.js",
   "description": "Display filter render as twist text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-twist.es.js",
-  "browser": "dist/filter-twist.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -22,7 +21,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/twist/package.json
+++ b/filters/twist/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-twist",
   "version": "2.4.0",
   "main": "lib/filter-twist.js",
-  "description": "Display filter render as twist text",
+  "description": "PixiJS v4 filter to apply a twist effect to a DisplayObject",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"

--- a/filters/twist/package.json
+++ b/filters/twist/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@pixi/filter-twist",
   "version": "2.4.0",
-  "main": "lib/filter-twist.js",
+  "main": "lib/filter-twist.cjs.js",
   "description": "Display filter render as twist text",
   "author": "Mat Groves",
   "contributors": [
     "Matt Karl <matt@mattkarl.com>"
   ],
   "module": "lib/filter-twist.es.js",
+  "browser": "dist/filter-twist.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -21,6 +22,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/twist/src/TwistFilter.js
+++ b/filters/twist/src/TwistFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './twist.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * This filter applies a twist effect making display objects appear twisted in the given direction.<br>
@@ -57,6 +58,3 @@ export default class TwistFilter extends PIXI.Filter {
         this.uniforms.angle = value;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.TwistFilter = TwistFilter;

--- a/filters/zoom-blur/README.md
+++ b/filters/zoom-blur/README.md
@@ -12,8 +12,9 @@ npm install @pixi/filter-zoom-blur
 
 ```js
 import { ZoomFilter } from '@pixi/filter-zoom-blur';
+import {Container} from 'pixi.js';
 
-const container = new PIXI.Container();
+const container = new Container();
 container.filters = [new ZoomFilter()];
 ```
 

--- a/filters/zoom-blur/README.md
+++ b/filters/zoom-blur/README.md
@@ -1,6 +1,6 @@
 # ZoomFilter
 
-PixiJS v4 filter to render Zoom Blur effect.
+PixiJS v4 filter to apply zoom blur effect.
 
 ## Installation
 
@@ -11,7 +11,7 @@ npm install @pixi/filter-zoom-blur
 ## Usage
 
 ```js
-import { ZoomFilter } from '@pixi/filter-zoom-blur';
+import {ZoomFilter} from '@pixi/filter-zoom-blur';
 import {Container} from 'pixi.js';
 
 const container = new Container();

--- a/filters/zoom-blur/package.json
+++ b/filters/zoom-blur/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@pixi/filter-zoom-blur",
   "version": "2.4.0",
-  "main": "lib/filter-zoom-blur.js",
+  "main": "lib/filter-zoom-blur.cjs.js",
   "description": "Zoom Blur filter",
   "author": "finscn",
   "contributors": [
     "finscn <finscn@gmail.com>"
   ],
   "module": "lib/filter-zoom-blur.es.js",
+  "browser": "dist/filter-zoom-blur.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -21,6 +22,7 @@
   },
   "files": [
     "lib",
+    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/zoom-blur/package.json
+++ b/filters/zoom-blur/package.json
@@ -2,7 +2,7 @@
   "name": "@pixi/filter-zoom-blur",
   "version": "2.4.0",
   "main": "lib/filter-zoom-blur.js",
-  "description": "Zoom Blur filter",
+  "description": "PixiJS v4 filter to apply zoom blur effect",
   "author": "finscn",
   "contributors": [
     "finscn <finscn@gmail.com>"

--- a/filters/zoom-blur/package.json
+++ b/filters/zoom-blur/package.json
@@ -1,14 +1,13 @@
 {
   "name": "@pixi/filter-zoom-blur",
   "version": "2.4.0",
-  "main": "lib/filter-zoom-blur.cjs.js",
+  "main": "lib/filter-zoom-blur.js",
   "description": "Zoom Blur filter",
   "author": "finscn",
   "contributors": [
     "finscn <finscn@gmail.com>"
   ],
   "module": "lib/filter-zoom-blur.es.js",
-  "browser": "dist/filter-zoom-blur.js",
   "types": "types.d.ts",
   "homepage": "http://pixijs.com/",
   "bugs": "https://github.com/pixijs/pixi-filters/issues",
@@ -22,7 +21,6 @@
   },
   "files": [
     "lib",
-    "dist",
     "types.d.ts"
   ],
   "peerDependencies": {

--- a/filters/zoom-blur/src/ZoomBlurFilter.js
+++ b/filters/zoom-blur/src/ZoomBlurFilter.js
@@ -1,5 +1,6 @@
 import {vertex} from '@tools/fragments';
 import fragment from './zoom-blur.frag';
+import * as PIXI from 'pixi.js';
 
 /**
  * The ZoomFilter applies a Zoom blur to an object.<br>
@@ -79,6 +80,3 @@ export default class ZoomBlurFilter extends PIXI.Filter {
         this.uniforms.uRadius = value;
     }
 }
-
-// Export to PixiJS namespace
-PIXI.filters.ZoomBlurFilter = ZoomBlurFilter;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "postinstall": "npm run bootstrap",
     "bootstrap": "lerna bootstrap --hoist",
-    "clean:build": "rimraf filters/*/lib \"bundle/{lib,dist}\" tools/screenshots/dist",
+    "clean:build": "rimraf \"filters/*/{lib,dist}\" \"bundle/{lib,dist}\" tools/screenshots/dist",
     "preclean": "npm run clean:build",
     "clean": "lerna clean",
     "predeploy": "npm run docs",
@@ -37,6 +37,7 @@
     "rimraf": "^2.6.2",
     "rollup": "^0.52.0",
     "rollup-plugin-buble": "^0.16.0",
+    "rollup-plugin-commonjs": "^8.2.6",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-string": "^2.0.2",
     "rollup-plugin-uglify": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "postinstall": "npm run bootstrap",
     "bootstrap": "lerna bootstrap --hoist",
-    "clean:build": "rimraf \"filters/*/{lib,dist}\" \"bundle/{lib,dist}\" tools/screenshots/dist",
+    "clean:build": "rimraf filters/*/lib \"bundle/{lib,dist}\" tools/screenshots/dist",
     "preclean": "npm run clean:build",
     "clean": "lerna clean",
     "predeploy": "npm run docs",

--- a/tools/demo/rollup.config.js
+++ b/tools/demo/rollup.config.js
@@ -16,8 +16,12 @@ if (process.argv.indexOf('--prod') > -1) {
 
 export default {
     input: 'src/index.js',
+    external: ['pixi.js'],
+    globals: {
+        'pixi.js': 'PIXI',
+    },
     output: {
-        format: 'umd',
+        format: 'iife',
         file: 'index.js'
     },
     plugins

--- a/tools/demo/src/DemoApplication.js
+++ b/tools/demo/src/DemoApplication.js
@@ -1,3 +1,6 @@
+import * as filters from 'pixi-filters';
+import * as PIXI from 'pixi.js';
+
 /*global dat,ga*/
 /**
  * Demo show a bunch of fish and a dat.gui controls
@@ -270,7 +273,7 @@ export default class DemoApplication extends PIXI.Application {
 
         const app = this;
         const folder = this.gui.addFolder(options.name);
-        const ClassRef = PIXI.filters[id];
+        const ClassRef = filters[id] || PIXI.filters[id];
 
         if (!ClassRef) {
             throw `Unable to find class name with "${id}"`;

--- a/tools/demo/src/filters/displacement.js
+++ b/tools/demo/src/filters/displacement.js
@@ -1,3 +1,5 @@
+import * as PIXI from 'pixi.js';
+
 export default function() {
     const app = this;
     this.resources.map.texture.baseTexture.wrapMode = PIXI.WRAP_MODES.REPEAT;

--- a/tools/demo/src/filters/godray.js
+++ b/tools/demo/src/filters/godray.js
@@ -1,3 +1,5 @@
+import * as PIXI from 'pixi.js';
+
 export default function() {
     const app = this;
 

--- a/tools/demo/src/filters/twist.js
+++ b/tools/demo/src/filters/twist.js
@@ -1,3 +1,5 @@
+import * as PIXI from 'pixi.js';
+
 export default function() {
     const app = this;
     this.addFilter('TwistFilter', function(folder) {

--- a/tools/demo/src/index.js
+++ b/tools/demo/src/index.js
@@ -1,4 +1,3 @@
-import 'pixi-filters';
 import './ga';
 import DemoApplication from './DemoApplication';
 import * as filters from './filters';

--- a/tools/screenshots/renderer.js
+++ b/tools/screenshots/renderer.js
@@ -1,5 +1,5 @@
-require('pixi.js');
-require('pixi-filters');
+const PIXI = require('pixi.js');
+const filters = require('pixi-filters');
 const assert = require('assert');
 const config = require('./config.json');
 const base64ToImage = require('base64-to-image');
@@ -53,7 +53,7 @@ function next() {
     const obj = config.images[++index];
     if (obj) {
 
-        const FilterClass = PIXI.filters[obj.name];
+        const FilterClass = filters[obj.name] || PIXI.filters[obj.name];
         assert(!!FilterClass, `Filter ${obj.name} does not exist`);
         let filter;
         switch(obj.name) {


### PR DESCRIPTION
Fixes #130

## Overview

~This change removes the default `umd` build format and replaces it with separate `cjs` and `iife` formats. This makes it easier to use the browser version OR use a module bundler to import. This delineates the worksflows more explicitly.~

This change does not require `PIXI` to be global in order to use with a module bundler. Instead, uses `global` and `external` settings in Rollup to support both browser and bundler based environments. Also, it uses **pixi.js** properly as a global peer dependency.

In addition, updates the README documentation.