### PR TITLE
Updates all dependencies, fixes colormap for v5

### DIFF
--- a/bundle/package.json
+++ b/bundle/package.json
@@ -25,9 +25,6 @@
     "dist",
     "types.d.ts"
   ],
-  "scripts": {
-    "postversion": "cd .. && npm run build"
-  },
   "peerDependencies": {
     "pixi.js": "^4.6.0"
   },

--- a/filters/color-map/src/ColorMapFilter.js
+++ b/filters/color-map/src/ColorMapFilter.js
@@ -63,13 +63,14 @@ export default class ColorMapFilter extends PIXI.Filter {
         return this._colorMap;
     }
     set colorMap(colorMap) {
-        const texture = PIXI.Texture.from(colorMap);
+        if (!(colorMap instanceof PIXI.Texture)) {
+            colorMap = PIXI.Texture.from(colorMap);
+        }
+        if (colorMap && colorMap.baseTexture) {
+            colorMap.baseTexture.scaleMode = this._scaleMode;
+            colorMap.baseTexture.mipmap = false;
 
-        if (texture && texture.baseTexture) {
-            texture.baseTexture.scaleMode = this._scaleMode;
-            texture.baseTexture.mipmap = false;
-
-            this._size = texture.height;
+            this._size = colorMap.height;
             this._sliceSize = 1 / this._size;
             this._slicePixelSize = this._sliceSize / this._size;
             this._sliceInnerSize = this._slicePixelSize * (this._size - 1);
@@ -79,10 +80,10 @@ export default class ColorMapFilter extends PIXI.Filter {
             this.uniforms._slicePixelSize = this._slicePixelSize;
             this.uniforms._sliceInnerSize = this._sliceInnerSize;
 
-            this.uniforms.colorMap = texture;
+            this.uniforms.colorMap = colorMap;
         }
 
-        this._colorMap = texture;
+        this._colorMap = colorMap;
     }
 
     /**

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.4.0",
+  "lerna": "2.9.0",
   "packages": [
     "bundle",
     "filters/*",

--- a/package.json
+++ b/package.json
@@ -23,24 +23,25 @@
     "lerna": "lerna",
     "prerelease": "npm run build",
     "release": "lerna publish",
-    "postrelease": "npm run deploy"
+    "postrelease": "npm run deploy",
+    "postversion": "npm run build"
   },
   "devDependencies": {
     "@pixi/jsdoc-template": "^2.2.0",
     "eslint": "^4.6.1",
-    "gh-pages": "^0.11.0",
-    "http-server": "^0.9.0",
+    "gh-pages": "^1.1.0",
+    "http-server": "^0.11.1",
     "jsdoc": "^3.4.0",
-    "lerna": "^2.4.0",
+    "lerna": "^2.9.0",
     "magic-string": "^0.22.4",
     "minimist": "^1.2.0",
     "rimraf": "^2.6.2",
-    "rollup": "^0.52.0",
-    "rollup-plugin-buble": "^0.16.0",
+    "rollup": "^0.56.3",
+    "rollup-plugin-buble": "^0.19.2",
     "rollup-plugin-commonjs": "^8.2.6",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-string": "^2.0.2",
-    "rollup-plugin-uglify": "^2.0.1",
-    "uglify-es": "^3.0.25"
+    "rollup-plugin-uglify": "^3.0.0",
+    "uglify-es": "^3.3.9"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -150,15 +150,23 @@ sorted.forEach((group) => {
 
         // UMD format output
         const mainOutput = {
+            name,
             file: path.join(basePath, main),
             format: 'umd',
             footer,
+            sourcemap,
+            banner,
+            globals,
         };
 
         // ES format output
         const moduleOutput = {
+            name,
             file: path.join(basePath, module),
             format: 'es',
+            sourcemap,
+            banner,
+            globals,
         };
 
         // For bundle, override and keep as vanilla-CommonJS
@@ -169,17 +177,13 @@ sorted.forEach((group) => {
         }
 
         results.push({
-            banner,
             input,
             freeze,
             output: [
                 mainOutput,
                 moduleOutput,
             ],
-            name,
-            globals,
             external,
-            sourcemap,
             plugins,
         });
 
@@ -188,19 +192,19 @@ sorted.forEach((group) => {
         // this will package all dependencies
         if (args.bundles && bundle) {
             results.push({
-                banner,
                 input,
                 freeze,
                 external: baseExternal,
-                globals,
                 output: {
+                    name,
+                    banner,
+                    globals,
                     file: path.join(basePath, bundle),
                     format: 'iife',
                     footer,
+                    sourcemap,
                 },
-                name,
                 treeshake: false,
-                sourcemap,
                 plugins,
             });
         }

--- a/tools/demo/package.json
+++ b/tools/demo/package.json
@@ -12,10 +12,10 @@
   "devDependencies": {
     "pixi-filters": "^2.5.1",
     "rimraf": "^2.6.2",
-    "rollup": "^0.52.0",
-    "rollup-plugin-buble": "^0.16.0",
+    "rollup": "^0.56.3",
+    "rollup-plugin-buble": "^0.19.2",
     "rollup-plugin-node-resolve": "^3.0.0",
-    "rollup-plugin-uglify": "^2.0.1",
+    "rollup-plugin-uglify": "^3.0.0",
     "rollup-watch": "^4.3.1"
   }
 }

--- a/tools/demo/rollup.config.js
+++ b/tools/demo/rollup.config.js
@@ -17,10 +17,10 @@ if (process.argv.indexOf('--prod') > -1) {
 export default {
     input: 'src/index.js',
     external: ['pixi.js'],
-    globals: {
-        'pixi.js': 'PIXI',
-    },
     output: {
+        globals: {
+            'pixi.js': 'PIXI',
+        },
         format: 'iife',
         file: 'index.js'
     },


### PR DESCRIPTION
### Changed
* Updates Rollup, Lerna and plugin dependencies
* Updates to new Rollup config format
* Removes `postversion` hack from Lerna < 2.7.0

### Fixed
* Fixes issue with setting `colorMap` with ColorMapFilter and v5