### PR TITLE
.gitattributes added

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.js    text eol=lf
+*.json  text eol=lf
+*.yml   text eol=lf
+*.md    text eol=lf
+*.txt   text eol=lf


### PR DESCRIPTION
stops all files showing up as changed when checking out and building on windows