### PR TITLE
Remove needless code

### DIFF
--- a/filters/glitch/src/GlitchFilter.js
+++ b/filters/glitch/src/GlitchFilter.js
@@ -247,7 +247,6 @@ export default class GlitchFilter extends PIXI.Filter {
             y += height;
         }
 
-        texture._updateID++;
         texture.baseTexture.emit('update', texture.baseTexture);
         this.uniforms.displacementMap = texture;
     }


### PR DESCRIPTION
updateID will be changed when call  ```texture.baseTexture.emit('update', texture.baseTexture);```