### PR TITLE
Adds support for velocity being an ObservablePoint

### DIFF
--- a/bundle/types.d.ts
+++ b/bundle/types.d.ts
@@ -222,8 +222,8 @@ declare namespace PIXI.filters {
         readonly clamp:boolean;
     }
     class MotionBlurFilter extends PIXI.Filter<{}> {
-        constructor(velocity:PIXI.Point|number[], kernelSize?:number, offset?:number);
-        velocity:PIXI.Point|number[];
+        constructor(velocity:PIXI.ObservablePoint|PIXI.Point|number[], kernelSize?:number, offset?:number);
+        velocity:PIXI.ObservablePoint;
         kernelSize:number;
         offset:number;
     }

--- a/filters/motion-blur/src/MotionBlurFilter.js
+++ b/filters/motion-blur/src/MotionBlurFilter.js
@@ -9,7 +9,7 @@ import * as PIXI from 'pixi.js';
  * @class
  * @extends PIXI.Filter
  * @memberof PIXI.filters
- * @param {PIXI.Point|number[]} [velocity=[0, 0]] Sets the velocity of the motion for blur effect.
+ * @param {PIXI.ObservablePoint|PIXI.Point|number[]} [velocity=[0, 0]] Sets the velocity of the motion for blur effect.
  * @param {number} [kernelSize=5] - The kernelSize of the blur filter. Must be odd number >= 5
  * @param {number} [offset=0] - The offset of the blur filter.
  */
@@ -17,7 +17,7 @@ export default class MotionBlurFilter extends PIXI.Filter {
     constructor(velocity = [0, 0], kernelSize = 5, offset = 0) {
         super(vertex, fragment);
         this.uniforms.uVelocity = new Float32Array(2);
-        this._velocity = new PIXI.Point(0,0);
+        this._velocity = new PIXI.ObservablePoint(this.velocityChanged, this);
         this.velocity = velocity;
 
         /**
@@ -44,25 +44,28 @@ export default class MotionBlurFilter extends PIXI.Filter {
     /**
      * Sets the velocity of the motion for blur effect.
      *
-     * @member {PIXI.Point|number[]}
-     * @default [0, 0]
+     * @member {PIXI.ObservablePoint}
      */
     set velocity(value) {
         if (Array.isArray(value)) {
-            this._velocity.x = value[0];
-            this._velocity.y = value[1];
+            this._velocity.set(value[0], value[1]);
         }
-        else if (value instanceof PIXI.Point) {
-            this._velocity.x = value.x;
-            this._velocity.y = value.y;
+        else if (value instanceof PIXI.Point || value instanceof PIXI.ObservablePoint) {
+            this._velocity.copy(value);
         }
-
-        this.uniforms.uVelocity[0] = this._velocity.x;
-        this.uniforms.uVelocity[1] = this._velocity.y;
     }
 
     get velocity() {
         return this._velocity;
+    }
+
+    /**
+     * Handle velocity changed
+     * @private
+     */
+    velocityChanged() {
+        this.uniforms.uVelocity[0] = this._velocity.x;
+        this.uniforms.uVelocity[1] = this._velocity.y;
     }
 
     /**

--- a/filters/motion-blur/types.d.ts
+++ b/filters/motion-blur/types.d.ts
@@ -1,8 +1,8 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
     class MotionBlurFilter extends PIXI.Filter<{}> {
-        constructor(velocity:PIXI.Point|number[], kernelSize?:number, offset?:number);
-        velocity:PIXI.Point|number[];
+        constructor(velocity:PIXI.ObservablePoint|PIXI.Point|number[], kernelSize?:number, offset?:number);
+        velocity:PIXI.ObservablePoint;
         kernelSize:number;
         offset:number;
     }

--- a/tools/demo/src/filters/motion-blur.js
+++ b/tools/demo/src/filters/motion-blur.js
@@ -1,23 +1,17 @@
 export default function() {
     const app = this;
-    let velocity = [40, 40];
 
     app.addFilter('MotionBlurFilter', {
         enabled: false,
         global: false,
-        args: [velocity, 15],
+        args: [[40, 40], 15],
         oncreate(folder) {
             const filter = this;
 
-            folder.add(velocity, '0', -90, 90).name('velocity.x').onChange(function() {
-                filter.velocity = velocity;
-            });
-            folder.add(velocity, '1', -90, 90).name('velocity.y').onChange(function() {
-                filter.velocity = velocity;
-            });
+            folder.add(filter.velocity, 'x', -90, 90).name('velocity.x');
+            folder.add(filter.velocity, 'y', -90, 90).name('velocity.y');
             folder.add(filter, 'kernelSize', [3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25]).name('kernelSize');
             folder.add(filter, 'offset', -150, 150).name('offset');
-
         }
     });
 }


### PR DESCRIPTION
Fixes #161 

### Changed

* MotionBlur's velocity property is now a `PIXI.ObservablePoint` so that changes automatically update the uniforms without needing to resetting `velocity`