### PR TITLE
Allow 0 as radius and strength argument

### DIFF
--- a/filters/bulge-pinch/src/BulgePinchFilter.js
+++ b/filters/bulge-pinch/src/BulgePinchFilter.js
@@ -24,8 +24,8 @@ export default class BulgePinchFilter extends PIXI.Filter {
         super(vertex, fragment);
         this.uniforms.dimensions = new Float32Array(2);
         this.center = center || [0.5, 0.5];
-        this.radius = radius || 100;
-        this.strength = strength || 1;
+        this.radius = (typeof radius === 'number') ? radius : 100; // allow 0 to be passed
+        this.strength = (typeof strength === 'number') ? strength : 1; // allow 0 to be passed
     }
 
     apply(filterManager, input, output, clear) {


### PR DESCRIPTION
Fixes issue that ignores if 0 is passed as "radius" or "strength".
```
this.radius = radius || 100 // 0 is evaluated as "false" and being ignored
```