### PR TITLE
Update color-map.frag to fix LUT bind issues

### DIFF
--- a/filters/color-map/src/color-map.frag
+++ b/filters/color-map/src/color-map.frag
@@ -1,28 +1,31 @@
-
 varying vec2 vTextureCoord;
 uniform sampler2D uSampler;
-
 uniform sampler2D colorMap;
-
 uniform float _mix;
 uniform float _size;
 uniform float _sliceSize;
 uniform float _slicePixelSize;
 uniform float _sliceInnerSize;
-
 void main() {
     vec4 color = texture2D(uSampler, vTextureCoord.xy);
 
-    float sliceIndex = color.b * (_size - 1.0);
-    float zSlice0 = floor(sliceIndex);
-    float zSlice1 = ceil(sliceIndex);
+    vec4 adjusted;
+    if (color.a > 0.0) {
+        color.rgb /= color.a;
+        float innerWidth = _size - 1.0;
+        float zSlice0 = min(floor(color.b * innerWidth), innerWidth);
+        float zSlice1 = min(zSlice0 + 1.0, innerWidth);
+        float xOffset = _slicePixelSize * 0.5 + color.r * _sliceInnerSize;
+        float s0 = xOffset + (zSlice0 * _sliceSize);
+        float s1 = xOffset + (zSlice1 * _sliceSize);
+        float yOffset = _sliceSize * 0.5 + color.g * (1.0 - _sliceSize);
+        vec4 slice0Color = texture2D(colorMap, vec2(s0,yOffset));
+        vec4 slice1Color = texture2D(colorMap, vec2(s1,yOffset));
+        float zOffset = fract(color.b * innerWidth);
+        adjusted = mix(slice0Color, slice1Color, zOffset);
 
-    float xOffset = _slicePixelSize * 0.5 + color.r * _sliceInnerSize;
-    float s0 = xOffset + zSlice0 * _sliceSize;
-    float s1 = xOffset + zSlice1 * _sliceSize;
-    vec4 slice0Color = texture2D(colorMap, vec2(s0, color.g));
-    vec4 slice1Color = texture2D(colorMap, vec2(s1, color.g));
-    vec4 adjusted = mix(slice0Color, slice1Color, fract(sliceIndex));
+        color.rgb *= color.a;
+    }
+    gl_FragColor = vec4(mix(color, adjusted, _mix).rgb, color.a);
 
-    gl_FragColor = mix(color, adjusted, _mix);
 }


### PR DESCRIPTION
Properly fixes the color-map frag shader.

Uses all 3 xyz offsets to properly adjust color.

Allows sprite alpha and fixes pre-mulitply

related to #171 
and fixes issues with #179 (I'd have modified his pr but I didn't know how) 