### PR TITLE
Provide options for bulge-pinch and zoom-blur

### DIFF
--- a/filters/bulge-pinch/src/BulgePinchFilter.js
+++ b/filters/bulge-pinch/src/BulgePinchFilter.js
@@ -16,18 +16,38 @@ import {Filter} from '@pixi/core';
  * @memberof PIXI.filters
  * @see {@link https://www.npmjs.com/package/@pixi/filter-bulge-pinch|@pixi/filter-bulge-pinch}
  * @see {@link https://www.npmjs.com/package/pixi-filters|pixi-filters}
- * @param {PIXI.Point|Array<number>} [center=[0,0]] The x and y coordinates of the center of the circle of effect.
- * @param {number} [radius=100] The radius of the circle of effect.
- * @param {number} [strength=1] -1 to 1 (-1 is strong pinch, 0 is no effect, 1 is strong bulge)
+ * @param {object} [options] Options to use for filter.
+ * @param {PIXI.Point|Array<number>} [options.center=[0,0]] The x and y coordinates of the center of the circle of effect.
+ * @param {number} [options.radius=100] The radius of the circle of effect.
+ * @param {number} [options.strength=1] -1 to 1 (-1 is strong pinch, 0 is no effect, 1 is strong bulge)
  */
 class BulgePinchFilter extends Filter {
 
-    constructor(center, radius, strength) {
+    constructor(options) {
         super(vertex, fragment);
+
+        // @deprecated (center, radius, strength) args
+        if (typeof options !== 'object') {
+            const [center, radius, strength] = arguments;
+            options = {};
+            if (center !== undefined) {
+                options.center = center;
+            }
+            if (radius !== undefined) {
+                options.radius = radius;
+            }
+            if (strength !== undefined) {
+                options.strength = strength;
+            }
+        }
+
         this.uniforms.dimensions = new Float32Array(2);
-        this.center = center || [0.5, 0.5];
-        this.radius = (typeof radius === 'number') ? radius : 100; // allow 0 to be passed
-        this.strength = (typeof strength === 'number') ? strength : 1; // allow 0 to be passed
+
+        Object.assign(this, {
+            center: [0.5, 0.5],
+            radius: 100,
+            strength: 1,
+        }, options);
     }
 
     apply(filterManager, input, output, clear) {

--- a/filters/bulge-pinch/types.d.ts
+++ b/filters/bulge-pinch/types.d.ts
@@ -1,9 +1,9 @@
 /// <reference types="pixi.js" />
 declare module "@pixi/filter-bulge-pinch" {
     export interface BulgePinchFilterOptions {
-        center:PIXI.Point|[number, number];
-        radius:number;
-        strength:number;
+        center?:PIXI.Point|[number, number];
+        radius?:number;
+        strength?:number;
     }
     export class BulgePinchFilter extends PIXI.Filter {
         constructor(options?:BulgePinchFilterOptions);

--- a/filters/bulge-pinch/types.d.ts
+++ b/filters/bulge-pinch/types.d.ts
@@ -1,7 +1,13 @@
 /// <reference types="pixi.js" />
 declare module "@pixi/filter-bulge-pinch" {
+    export interface BulgePinchFilterOptions {
+        center:PIXI.Point|[number, number];
+        radius:number;
+        strength:number;
+    }
     export class BulgePinchFilter extends PIXI.Filter {
-        constructor(center?:PIXI.Point|number[], radius?:number, strength?:number);
+        constructor(options?:BulgePinchFilterOptions);
+        constructor(center?:PIXI.Point|[number, number], radius?:number, strength?:number);
         center:PIXI.Point;
         radius:number;
         strength:number;

--- a/filters/zoom-blur/src/ZoomBlurFilter.js
+++ b/filters/zoom-blur/src/ZoomBlurFilter.js
@@ -11,19 +11,40 @@ import {Filter} from '@pixi/core';
  * @memberof PIXI.filters
  * @see {@link https://www.npmjs.com/package/@pixi/filter-zoom-blur|@pixi/filter-zoom-blur}
  * @see {@link https://www.npmjs.com/package/pixi-filters|pixi-filters}
- * @param {number} [strength=0.1] Sets the strength of the zoom blur effect
- * @param {PIXI.Point|number[]} [center=[0,0]] The center of the zoom.
- * @param {number} [innerRadius=0] The inner radius of zoom. The part in inner circle won't apply zoom blur effect.
- * @param {number} [radius=-1] See `radius` property.
+ * @param {object} [options] Filter options to use.
+ * @param {number} [options.strength=0.1] Sets the strength of the zoom blur effect
+ * @param {PIXI.Point|number[]} [options.center=[0,0]] The center of the zoom.
+ * @param {number} [options.innerRadius=0] The inner radius of zoom. The part in inner circle won't apply zoom blur effect.
+ * @param {number} [options.radius=-1] See `radius` property.
  */
 class ZoomBlurFilter extends Filter {
-    constructor(strength = 0.1, center = [0, 0], innerRadius = 0, radius = -1) {
+    constructor(options) {
         super(vertex, fragment);
 
-        this.center = center;
-        this.strength = strength;
-        this.innerRadius = innerRadius;
-        this.radius = radius;
+        // @deprecated (strength, center, innerRadius, radius) args
+        if (typeof options !== 'object') {
+            const [strength, center, innerRadius, radius] = arguments;
+            options = {};
+            if (strength !== undefined) {
+                options.strength = strength;
+            }
+            if (center !== undefined) {
+                options.center = center;
+            }
+            if (innerRadius !== undefined) {
+                options.innerRadius = innerRadius;
+            }
+            if (radius !== undefined) {
+                options.radius = radius;
+            }
+        }
+
+        Object.assign(this, {
+            strength: 0.1,
+            center: [0, 0],
+            innerRadius: 0,
+            radius: -1,
+        }, options);
     }
 
     /**

--- a/filters/zoom-blur/types.d.ts
+++ b/filters/zoom-blur/types.d.ts
@@ -1,10 +1,10 @@
 /// <reference types="pixi.js" />
 declare module "@pixi/filter-zoom-blur" {
     export interface ZoomBlurFilterOptions {
-        strength:number;
-        center:PIXI.Point|[number, number];
-        innerRadius:number;
-        radius:number;
+        strength?:number;
+        center?:PIXI.Point|[number, number];
+        innerRadius?:number;
+        radius?:number;
     }
     export class ZoomBlurFilter extends PIXI.Filter {
         constructor(options?:ZoomBlurFilterOptions);

--- a/filters/zoom-blur/types.d.ts
+++ b/filters/zoom-blur/types.d.ts
@@ -1,6 +1,13 @@
 /// <reference types="pixi.js" />
 declare module "@pixi/filter-zoom-blur" {
+    export interface ZoomBlurFilterOptions {
+        strength:number;
+        center:PIXI.Point|number[];
+        innerRadius:number;
+        radius:number;
+    }
     export class ZoomBlurFilter extends PIXI.Filter {
+        constructor(options?:ZoomBlurFilterOptions);
         constructor(strength?:number, center?:PIXI.Point|number[], innerRadius?:number, radius?:number);
         strength:number;
         center:PIXI.Point|number[];

--- a/filters/zoom-blur/types.d.ts
+++ b/filters/zoom-blur/types.d.ts
@@ -2,15 +2,15 @@
 declare module "@pixi/filter-zoom-blur" {
     export interface ZoomBlurFilterOptions {
         strength:number;
-        center:PIXI.Point|number[];
+        center:PIXI.Point|[number, number];
         innerRadius:number;
         radius:number;
     }
     export class ZoomBlurFilter extends PIXI.Filter {
         constructor(options?:ZoomBlurFilterOptions);
-        constructor(strength?:number, center?:PIXI.Point|number[], innerRadius?:number, radius?:number);
+        constructor(strength?:number, center?:PIXI.Point|[number, number], innerRadius?:number, radius?:number);
         strength:number;
-        center:PIXI.Point|number[];
+        center:PIXI.Point|[number, number];
         innerRadius:number;
         radius:number;
     }

--- a/tools/demo/src/filters/zoom-blur.js
+++ b/tools/demo/src/filters/zoom-blur.js
@@ -1,7 +1,11 @@
 export default function() {
     const app = this;
     this.addFilter('ZoomBlurFilter', {
-        args: [0.1, [app.initWidth / 2, app.initHeight / 2], 80],
+        args: [{
+            strength: 0.1,
+            center: [app.initWidth / 2, app.initHeight / 2],
+            innerRadius: 80
+        }],
         oncreate(folder) {
             folder.add(this, 'strength', 0.01, 0.5);
             folder.add(this.center, '0', 0, app.initWidth).name('center.x');


### PR DESCRIPTION
These particular filters (BulgePinchFilter and ZoomBlurFilter) had 3 or more constructor arguments that had defaults but where the order didn't make much logic sense. This PR provide alternative constructor options that can be set instead of flat arguments. Non-breaking, but encourages the use of the options by only documenting options.