### PR TITLE
Publish exact version of all internal deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "watch": "rollup -cw",
     "lerna": "lerna",
     "prerelease": "run-s build",
-    "release": "lerna publish",
+    "release": "lerna publish --exact",
     "postrelease": "run-s deploy",
     "postversion": "npm run build"
   },


### PR DESCRIPTION
# Summary
Publish exact version of all workspace deps so specific version in consumers projects will be honored
In similar manner as in: https://github.com/pixijs/pixi.js/pull/6211

# Background
package.json:
![image](https://user-images.githubusercontent.com/8374421/75782567-5f473580-5d5f-11ea-84a2-4e8f91343ca8.png)
Error: 
![image](https://user-images.githubusercontent.com/8374421/75782642-8271e500-5d5f-11ea-9fd8-b7b88b540aaa.png)
` TS2554: Expected 0-1 arguments, but got 5.`


Looks like I'm downloading pixi filters 3.1.0 instead of 3.0.3