### PR TITLE
Support PIXI.filters namespace

### DIFF
--- a/filters/adjustment/types.d.ts
+++ b/filters/adjustment/types.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-adjustment" {
+declare namespace PIXI.filters {
     export class AdjustmentFilter extends PIXI.Filter {
         constructor(options?: AdjustmentOptions);
         gamma: number;
@@ -21,4 +21,9 @@ declare module "@pixi/filter-adjustment" {
         blue?: number;
         alpha?: number;
     }
+}
+
+declare module "@pixi/filter-adjustment" {
+    export import AdjustmentFilter = PIXI.filters.AdjustmentFilter;
+    export import AdjustmentOptions = PIXI.filters.AdjustmentOptions;
 }

--- a/filters/advanced-bloom/types.d.ts
+++ b/filters/advanced-bloom/types.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-advanced-bloom" {
+declare namespace PIXI.filters {
     export class AdvancedBloomFilter extends PIXI.Filter {
         constructor(options?: AdvancedBloomOptions);
         constructor(threshold?: number);
@@ -22,4 +22,9 @@ declare module "@pixi/filter-advanced-bloom" {
         pixelSize?: number|PIXI.Point|number[];
         resolution?: number;
     }
+}
+
+declare module "@pixi/filter-advanced-bloom" {
+    export import AdvancedBloomFilter = PIXI.filters.AdvancedBloomFilter;
+    export import AdvancedBloomOptions = PIXI.filters.AdvancedBloomOptions;
 }

--- a/filters/ascii/types.d.ts
+++ b/filters/ascii/types.d.ts
@@ -1,7 +1,11 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-ascii" {
+declare namespace PIXI.filters {
     export class AsciiFilter extends PIXI.Filter {
         constructor(size?:number);
         size:number;
     }
+}
+
+declare module "@pixi/filter-ascii" {
+    export import AsciiFilter = PIXI.filters.AsciiFilter;
 }

--- a/filters/bevel/types.d.ts
+++ b/filters/bevel/types.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-bevel" {
+declare namespace PIXI.filters {
     export class BevelFilter extends PIXI.Filter {
         constructor(options?:BevelOptions);
         rotation:number;
@@ -17,4 +17,9 @@ declare module "@pixi/filter-bevel" {
         shadowColor:number;
         shadowAlpha:number;
     }
+}
+
+declare module "@pixi/filter-bevel" {
+    export import BevelFilter = PIXI.filters.BevelFilter;
+    export import BevelOptions = PIXI.filters.BevelOptions;
 }

--- a/filters/bloom/types.d.ts
+++ b/filters/bloom/types.d.ts
@@ -1,9 +1,13 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-bloom" {
+declare namespace PIXI.filters {
     export class BloomFilter extends PIXI.Filter {
         constructor(blur?:number|PIXI.Point|number[], quality?:number, resolution?:number, kernelSize?:number);
         blur:number;
         blurX:number;
         blurY:number;
     }
+}
+
+declare module "@pixi/filter-bloom" {
+    export import BloomFilter = PIXI.filters.BloomFilter;
 }

--- a/filters/bulge-pinch/types.d.ts
+++ b/filters/bulge-pinch/types.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-bulge-pinch" {
+declare namespace PIXI.filters {
     export interface BulgePinchFilterOptions {
         center?:PIXI.Point|[number, number];
         radius?:number;
@@ -12,4 +12,9 @@ declare module "@pixi/filter-bulge-pinch" {
         radius:number;
         strength:number;
     }
+}
+
+declare module "@pixi/filter-bulge-pinch" {
+    export import BulgePinchFilterOptions = PIXI.filters.BulgePinchFilterOptions;
+    export import BulgePinchFilter = PIXI.filters.BulgePinchFilter;
 }

--- a/filters/color-map/types.d.ts
+++ b/filters/color-map/types.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-color-map" {
+declare namespace PIXI.filters {
     export class ColorMapFilter extends PIXI.Filter {
         constructor(colorMap?:HTMLImageElement|HTMLCanvasElement|PIXI.BaseTexture|PIXI.Texture, nearest?:boolean, mix?:number);
         colorMap:PIXI.Texture;
@@ -7,4 +7,8 @@ declare module "@pixi/filter-color-map" {
         mix:number;
         readonly colorSize:number;
     }
+}
+
+declare module "@pixi/filter-color-map" {
+    export import ColorMapFilter = PIXI.filters.ColorMapFilter;
 }

--- a/filters/color-overlay/types.d.ts
+++ b/filters/color-overlay/types.d.ts
@@ -1,7 +1,11 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-color-overlay" {
+declare namespace PIXI.filters {
     export class ColorOverlayFilter extends PIXI.Filter {
         constructor(color?:number|[number, number, number]);
         color:number|[number, number, number];
     }
+}
+
+declare module "@pixi/filter-color-overlay" {
+    export import ColorOverlayFilter = PIXI.filters.ColorOverlayFilter;
 }

--- a/filters/color-replace/types.d.ts
+++ b/filters/color-replace/types.d.ts
@@ -1,9 +1,13 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-color-replace" {
+declare namespace PIXI.filters {
     export class ColorReplaceFilter extends PIXI.Filter {
         constructor(originalColor?:number|number[], newColor?:number|number[], epsilon?:number);
         epsilon:number;
         originalColor:number|number[];
         newColor:number|number[];
     }
+}
+
+declare module "@pixi/filter-color-replace" {
+    export import ColorReplaceFilter = PIXI.filters.ColorReplaceFilter;
 }

--- a/filters/convolution/types.d.ts
+++ b/filters/convolution/types.d.ts
@@ -1,9 +1,13 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-convolution" {
+declare namespace PIXI.filters {
     export class ConvolutionFilter extends PIXI.Filter {
         constructor(matrix:number[], width:number, height:number);
         height:number;
         width:number;
         matrix:number[];
     }
+}
+
+declare module "@pixi/filter-convolution" {
+    export import ConvolutionFilter = PIXI.filters.ConvolutionFilter;
 }

--- a/filters/cross-hatch/types.d.ts
+++ b/filters/cross-hatch/types.d.ts
@@ -1,6 +1,10 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-cross-hatch" {
+declare namespace PIXI.filters {
     class CrossHatchFilter extends PIXI.Filter {
         constructor();
     }
+}
+
+declare module "@pixi/filter-cross-hatch" {
+    export import CrossHatchFilter = PIXI.filters.CrossHatchFilter;
 }

--- a/filters/crt/types.d.ts
+++ b/filters/crt/types.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-crt" {
+declare namespace PIXI.filters {
     export class CRTFilter extends PIXI.Filter {
-        constructor(options?: CRTOptions);
+        constructor(options?: CRTFilterOptions);
         curvature: number;
         lineWidth: number;
         lineContrast: number;
@@ -14,7 +14,7 @@ declare module "@pixi/filter-crt" {
         vignettingBlur: number;
         time: number;
     }
-    export interface CRTOptions {
+    export interface CRTFilterOptions {
         curvature?: number;
         lineWidth?: number;
         lineContrast?: number;
@@ -27,4 +27,9 @@ declare module "@pixi/filter-crt" {
         vignettingBlur?: number;
         time?: number;
     }
+}
+
+declare module "@pixi/filter-crt" {
+    export import CRTFilter = PIXI.filters.CRTFilter;
+    export import CRTFilterOptions = PIXI.filters.CRTFilterOptions;
 }

--- a/filters/dot/types.d.ts
+++ b/filters/dot/types.d.ts
@@ -1,8 +1,12 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-dot" {
+declare namespace PIXI.filters {
     export class DotFilter extends PIXI.Filter {
         constructor(scale?:number, angle?:number);
         angle:number;
         scale:number;
     }
+}
+
+declare module "@pixi/filter-dot" {
+    export import DotFilter = PIXI.filters.DotFilter;
 }

--- a/filters/drop-shadow/types.d.ts
+++ b/filters/drop-shadow/types.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-drop-shadow" {
+declare namespace PIXI.filters {
     export class DropShadowFilter extends PIXI.Filter {
         constructor(options?:DropShadowFilterOptions);
         alpha:number;
@@ -25,4 +25,9 @@ declare module "@pixi/filter-drop-shadow" {
         rotation?:number;
         shadowOnly?:boolean;
     }
+}
+
+declare module "@pixi/filter-drop-shadow" {
+    export import DropShadowFilter = PIXI.filters.DropShadowFilter;
+    export import DropShadowFilterOptions = PIXI.filters.DropShadowFilterOptions;
 }

--- a/filters/emboss/types.d.ts
+++ b/filters/emboss/types.d.ts
@@ -1,7 +1,11 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-emboss" {
+declare namespace PIXI.filters {
     export class EmbossFilter extends PIXI.Filter {
         constructor(strength?:number);
         strength:number;
     }
+}
+
+declare module "@pixi/filter-emboss" {
+    export import EmbossFilter = PIXI.filters.EmbossFilter;
 }

--- a/filters/glitch/types.d.ts
+++ b/filters/glitch/types.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-glitch" {
+declare namespace PIXI.filters {
     export class GlitchFilter extends PIXI.Filter {
-        constructor(options?:GlitchOptions);
+        constructor(options?:GlitchFilterOptions);
         slices:number;
         offset:number;
         direction:number;
@@ -17,7 +17,7 @@ declare module "@pixi/filter-glitch" {
         redraw(): void;
         readonly texture:PIXI.Texture;
     }
-    export interface GlitchOptions {
+    export interface GlitchFilterOptions {
         slices:number;
         offset:number;
         direction:number;
@@ -30,4 +30,9 @@ declare module "@pixi/filter-glitch" {
         minSize:number;
         sampleSize:number;
     }
+}
+
+declare module "@pixi/filter-glitch" {
+    export import GlitchFilter = PIXI.filters.GlitchFilter;
+    export import GlitchFilterOptions = PIXI.filters.GlitchFilterOptions;
 }

--- a/filters/glow/types.d.ts
+++ b/filters/glow/types.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-glow" {
+declare namespace PIXI.filters {
     export class GlowFilter extends PIXI.Filter {
         constructor(options?:GlowFilterOptions);
         color:number;
@@ -15,4 +15,9 @@ declare module "@pixi/filter-glow" {
         quality?:number;
         knockout?:boolean;
     }
+}
+
+declare module "@pixi/filter-glow" {
+    export import GlowFilter = PIXI.filters.GlowFilter;
+    export import GlowFilterOptions = PIXI.filters.GlowFilterOptions;
 }

--- a/filters/godray/types.d.ts
+++ b/filters/godray/types.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-godray" {
+declare namespace PIXI.filters {
     export class GodrayFilter extends PIXI.Filter {
         constructor(options?:GodrayFilterOptions);
         angle:number;
@@ -17,4 +17,9 @@ declare module "@pixi/filter-godray" {
         lacunarity:number;
         time:number;
     }
+}
+
+declare module "@pixi/filter-godray" {
+    export import GodrayFilter = PIXI.filters.GodrayFilter;
+    export import GodrayFilterOptions = PIXI.filters.GodrayFilterOptions;
 }

--- a/filters/kawase-blur/types.d.ts
+++ b/filters/kawase-blur/types.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-kawase-blur" {
+declare namespace PIXI.filters {
     export class KawaseBlurFilter extends PIXI.Filter {
         constructor(blur?:number|number[], quality?:number, clamp?:boolean);
         kernels:number[];
@@ -8,4 +8,8 @@ declare module "@pixi/filter-kawase-blur" {
         blur:number;
         readonly clamp:boolean;
     }
+}
+
+declare module "@pixi/filter-kawase-blur" {
+    export import KawaseBlurFilter = PIXI.filters.KawaseBlurFilter;
 }

--- a/filters/motion-blur/types.d.ts
+++ b/filters/motion-blur/types.d.ts
@@ -1,9 +1,13 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-motion-blur" {
+declare namespace PIXI.filters {
     export class MotionBlurFilter extends PIXI.Filter {
         constructor(velocity:PIXI.ObservablePoint|PIXI.Point|number[], kernelSize?:number, offset?:number);
         velocity:PIXI.ObservablePoint;
         kernelSize:number;
         offset:number;
     }
+}
+
+declare module "@pixi/filter-motion-blur" {
+    export import MotionBlurFilter = PIXI.filters.MotionBlurFilter;
 }

--- a/filters/multi-color-replace/types.d.ts
+++ b/filters/multi-color-replace/types.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-multi-color-replace" {
+declare namespace PIXI.filters {
     export class MultiColorReplaceFilter extends PIXI.Filter {
         constructor(replacements:Array<number[]|number[][]>, epsilon?:number, maxColors?:number);
         replacements:Array<number[]|number[][]>;
@@ -7,4 +7,8 @@ declare module "@pixi/filter-multi-color-replace" {
         readonly maxColors:number;
         refresh():void;
     }
+}
+
+declare module "@pixi/filter-multi-color-replace" {
+    export import MultiColorReplaceFilter = PIXI.filters.MultiColorReplaceFilter;
 }

--- a/filters/old-film/types.d.ts
+++ b/filters/old-film/types.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-old-film" {
+declare namespace PIXI.filters {
     export class OldFilmFilter extends PIXI.Filter {
-        constructor(options?: OldFilmOptions, seed?: number);
+        constructor(options?: OldFilmFilterOptions, seed?: number);
         constructor(seed?: number);
         sepia: number;
         noise: number;
@@ -14,7 +14,7 @@ declare module "@pixi/filter-old-film" {
         vignettingBlur: number;
         seed: number;
     }
-    export interface OldFilmOptions {
+    export interface OldFilmFilterOptions {
         sepia?: number;
         noise?: number;
         noiseSize?: number;
@@ -25,4 +25,9 @@ declare module "@pixi/filter-old-film" {
         vignettingAlpha?: number;
         vignettingBlur?: number;
     }
+}
+
+declare module "@pixi/filter-old-film" {
+    export import OldFilmFilter = PIXI.filters.OldFilmFilter;
+    export import OldFilmFilterOptions = PIXI.filters.OldFilmFilterOptions;
 }

--- a/filters/outline/types.d.ts
+++ b/filters/outline/types.d.ts
@@ -1,9 +1,13 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-outline" {
+declare namespace PIXI.filters {
     export class OutlineFilter extends PIXI.Filter {
         constructor(thickness?:number, color?:number, quality?:number);
         color:number;
         thickness:number;
         readonly quality:number;
     }
+}
+
+declare module "@pixi/filter-outline" {
+    export import OutlineFilter = PIXI.filters.OutlineFilter;
 }

--- a/filters/pixelate/types.d.ts
+++ b/filters/pixelate/types.d.ts
@@ -1,7 +1,11 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-pixelate" {
+declare namespace PIXI.filters {
     export class PixelateFilter extends PIXI.Filter {
         constructor(size?:PIXI.Point|number[]|number);
         size:PIXI.Point|number[]|number;
     }
+}
+
+declare module "@pixi/filter-pixelate" {
+    export import PixelateFilter = PIXI.filters.PixelateFilter;
 }

--- a/filters/radial-blur/types.d.ts
+++ b/filters/radial-blur/types.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-radial-blur" {
+declare namespace PIXI.filters {
     export class RadialBlurFilter extends PIXI.Filter {
         constructor(angle?:number, center?:number[]|PIXI.Point, kernelSize?:number, radius?:number);
         angle:number;
@@ -7,4 +7,8 @@ declare module "@pixi/filter-radial-blur" {
         kernelSize:number;
         radius:number;
     }
+}
+
+declare module "@pixi/filter-radial-blur" {
+    export import RadialBlurFilter = PIXI.filters.RadialBlurFilter;
 }

--- a/filters/reflection/types.d.ts
+++ b/filters/reflection/types.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-reflection" {
+declare namespace PIXI.filters {
     export class ReflectionFilter extends PIXI.Filter {
-        constructor(options?: ReflectionOptions);
+        constructor(options?: ReflectionFilterOptions);
         mirror: boolean;
         boundary: number;
         amplitude: number[];
@@ -9,7 +9,7 @@ declare module "@pixi/filter-reflection" {
         alpha: number[];
         time: number;
     }
-    interface ReflectionOptions {
+    interface ReflectionFilterOptions {
         mirror?: boolean;
         boundary?: number;
         amplitude?: number[];
@@ -17,4 +17,9 @@ declare module "@pixi/filter-reflection" {
         alpha?: number[];
         time?: number;
     }
+}
+
+declare module "@pixi/filter-reflection" {
+    export import ReflectionFilter = PIXI.filters.ReflectionFilter;
+    export import ReflectionFilterOptions = PIXI.filters.ReflectionFilterOptions;
 }

--- a/filters/rgb-split/types.d.ts
+++ b/filters/rgb-split/types.d.ts
@@ -1,9 +1,14 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-rgb-split" {
+declare namespace PIXI.filters {
     export class RGBSplitFilter extends PIXI.Filter {
         constructor(red?:PIXI.Point, green?:PIXI.Point, blue?:PIXI.Point);
         red:PIXI.Point;
         green:PIXI.Point;
         blue:PIXI.Point;
     }
+}
+
+declare module "@pixi/filter-rgb-split" {
+    export import RGBSplitFilter = PIXI.filters.RGBSplitFilter;
+    
 }

--- a/filters/shockwave/types.d.ts
+++ b/filters/shockwave/types.d.ts
@@ -1,16 +1,21 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-shockwave" {
+declare namespace PIXI.filters {
     export class ShockwaveFilter extends PIXI.Filter {
-        constructor(center?:PIXI.Point|number[], options?:ShockwaveOptions, time?:number);
+        constructor(center?:PIXI.Point|number[], options?:ShockwaveFilterOptions, time?:number);
         center: PIXI.Point|number[];
-        options: ShockwaveOptions;
+        options: ShockwaveFilterOptions;
         time: number;
     }
-    export interface ShockwaveOptions {
+    export interface ShockwaveFilterOptions {
         amplitude?: number;
         wavelength?: number;
         brightness?: number;
         speed?: number;
         radius?: number;
     }
+}
+
+declare module "@pixi/filter-shockwave" {
+    export import ShockwaveFilter = PIXI.filters.ShockwaveFilter;
+    export import ShockwaveFilterOptions = PIXI.filters.ShockwaveFilterOptions;
 }

--- a/filters/simple-lightmap/types.d.ts
+++ b/filters/simple-lightmap/types.d.ts
@@ -1,9 +1,13 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-simple-lightmap" {
+declare namespace PIXI.filters {
     export class SimpleLightmapFilter extends PIXI.Filter {
         constructor(texture:PIXI.Texture, color?:number[]|number);
         alpha:number;
         color:number[]|number;
         texture:PIXI.Texture;
     }
+}
+
+declare module "@pixi/filter-simple-lightmap" {
+    export import SimpleLightmapFilter = PIXI.filters.SimpleLightmapFilter;
 }

--- a/filters/tilt-shift/types.d.ts
+++ b/filters/tilt-shift/types.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-tilt-shift" {
+declare namespace PIXI.filters {
     export class TiltShiftFilter extends PIXI.Filter {
         constructor(blur?:number, gradientBlur?:number, start?:PIXI.Point, end?:PIXI.Point);
         blur:number;
@@ -7,4 +7,8 @@ declare module "@pixi/filter-tilt-shift" {
         gradientBlur:number;
         start:PIXI.Point;
     }
+}
+
+declare module "@pixi/filter-tilt-shift" {
+    export import TiltShiftFilter = PIXI.filters.TiltShiftFilter;
 }

--- a/filters/twist/types.d.ts
+++ b/filters/twist/types.d.ts
@@ -1,9 +1,13 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-twist" {
+declare namespace PIXI.filters {
     export class TwistFilter extends PIXI.Filter {
         constructor(radius?:number, angle?:number, padding?:number);
         angle:number;
         offset:PIXI.Point;
         radius:number;
     }
+}
+
+declare module "@pixi/filter-twist" {
+    export import TwistFilter = PIXI.filters.TwistFilter;
 }

--- a/filters/zoom-blur/types.d.ts
+++ b/filters/zoom-blur/types.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="pixi.js" />
-declare module "@pixi/filter-zoom-blur" {
+declare namespace PIXI.filters {
     export interface ZoomBlurFilterOptions {
         strength?:number;
         center?:PIXI.Point|[number, number];
@@ -14,4 +14,9 @@ declare module "@pixi/filter-zoom-blur" {
         innerRadius:number;
         radius:number;
     }
+}
+
+declare module "@pixi/filter-zoom-blur" {
+    export import ZoomBlurFilterOptions = PIXI.filters.ZoomBlurFilterOptions;
+    export import ZoomBlurFilter = PIXI.filters.ZoomBlurFilter;
 }


### PR DESCRIPTION
Fixes #249

This provides `PIXI.filters` namespace for typings. Can be useful if you are not using bundler, or you are linking to the dist version of individual filters or pixi-filters.