### PR TITLE
Convert clear to clearModes to be compatible with 5.3.0+

### DIFF
--- a/filters/advanced-bloom/src/AdvancedBloomFilter.js
+++ b/filters/advanced-bloom/src/AdvancedBloomFilter.js
@@ -84,11 +84,11 @@ class AdvancedBloomFilter extends Filter {
 
         const brightTarget = filterManager.getFilterTexture();
 
-        this._extractFilter.apply(filterManager, input, brightTarget, true, currentState);
+        this._extractFilter.apply(filterManager, input, brightTarget, 1, currentState);
 
         const bloomTarget = filterManager.getFilterTexture();
 
-        this._blurFilter.apply(filterManager, brightTarget, bloomTarget, true, currentState);
+        this._blurFilter.apply(filterManager, brightTarget, bloomTarget, 1, currentState);
 
         this.uniforms.bloomScale = this.bloomScale;
         this.uniforms.brightness = this.brightness;

--- a/filters/drop-shadow/src/DropShadowFilter.js
+++ b/filters/drop-shadow/src/DropShadowFilter.js
@@ -90,11 +90,11 @@ class DropShadowFilter extends Filter {
     apply(filterManager, input, output, clear) {
         const target = filterManager.getFilterTexture();
 
-        this._tintFilter.apply(filterManager, input, target, true);
+        this._tintFilter.apply(filterManager, input, target, 1);
         this._blurFilter.apply(filterManager, target, output, clear);
 
         if (this.shadowOnly !== true) {
-            filterManager.applyFilter(this, input, output, false);
+            filterManager.applyFilter(this, input, output, 0);
         }
 
         filterManager.returnFilterTexture(target);

--- a/filters/kawase-blur/src/KawaseBlurFilter.js
+++ b/filters/kawase-blur/src/KawaseBlurFilter.js
@@ -68,7 +68,7 @@ class KawaseBlurFilter extends Filter {
                 offset = this._kernels[i] + 0.5;
                 this.uniforms.uOffset[0] = offset * uvX;
                 this.uniforms.uOffset[1] = offset * uvY;
-                filterManager.applyFilter(this, source, target, true);
+                filterManager.applyFilter(this, source, target, 1);
 
                 tmp = source;
                 source = target;


### PR DESCRIPTION
Fixes #251

Converting `clear` to a number supports both <5.3.0 and >=5.3.0. This property was converted to a constant `CLEAR_MODES`, this seemed like easy solution to ignore the deprecation warnings.