### PR TITLE
Add alpha support to godray filter

### DIFF
--- a/filters/godray/src/GodrayFilter.js
+++ b/filters/godray/src/GodrayFilter.js
@@ -1,8 +1,8 @@
-import { vertex } from '@tools/fragments';
+import {vertex} from '@tools/fragments';
 import perlin from './perlin.frag';
 import fragment from './gorday.frag';
-import { Filter } from '@pixi/core';
-import { Point, DEG_TO_RAD } from '@pixi/math';
+import {Filter} from '@pixi/core';
+import {Point, DEG_TO_RAD} from '@pixi/math';
 
 /**
  * GordayFilter, {@link https://codepen.io/alaingalvan originally} by Alain Galvan
@@ -26,7 +26,7 @@ import { Point, DEG_TO_RAD } from '@pixi/math';
  * @param {number} [options.time=0] The current time position.
  * @param {PIXI.Point|number[]} [options.center=[0,0]] Focal point for non-parallel rays,
  *        to use this `parallel` must be set to `false`.
- * @param {number} [options.alpha=0.5] the alpha
+ * @param {number} [options.alpha=1.0] the alpha, defaults to 1, affects transparency of rays
  */
 class GodrayFilter extends Filter {
     constructor(options) {
@@ -37,9 +37,7 @@ class GodrayFilter extends Filter {
         // Fallback support for ctor: (angle, gain, lacunarity, time)
         if (typeof options === 'number') {
             // eslint-disable-next-line no-console
-            console.warn(
-                'GodrayFilter now uses options instead of (angle, gain, lacunarity, time)'
-            );
+            console.warn('GodrayFilter now uses options instead of (angle, gain, lacunarity, time)');
             options = { angle: options };
             if (arguments[1] !== undefined) {
                 options.gain = arguments[1];
@@ -55,18 +53,15 @@ class GodrayFilter extends Filter {
             }
         }
 
-        options = Object.assign(
-            {
-                angle: 30,
-                gain: 0.5,
-                lacunarity: 2.5,
-                time: 0,
-                parallel: true,
-                center: [0, 0],
-                alpha: 0.0,
-            },
-            options
-        );
+        options = Object.assign({
+            angle: 30,
+            gain: 0.5,
+            lacunarity: 2.5,
+            time: 0,
+            parallel: true,
+            center: [0, 0],
+            alpha: 1,
+        }, options);
 
         this._angleLight = new Point();
         this.angle = options.angle;
@@ -75,41 +70,41 @@ class GodrayFilter extends Filter {
         this.alpha = options.alpha;
 
         /**
-     * `true` if light rays are parallel (uses angle),
-     * `false` to use the focal `center` point
-     *
-     * @member {boolean}
-     * @default true
-     */
+         * `true` if light rays are parallel (uses angle),
+         * `false` to use the focal `center` point
+         *
+         * @member {boolean}
+         * @default true
+         */
         this.parallel = options.parallel;
 
         /**
-     * The position of the emitting point for light rays
-     * only used if `parallel` is set to `false`.
-     *
-     * @member {PIXI.Point|number[]}
-     * @default [0, 0]
-     */
+         * The position of the emitting point for light rays
+         * only used if `parallel` is set to `false`.
+         *
+         * @member {PIXI.Point|number[]}
+         * @default [0, 0]
+         */
         this.center = options.center;
 
         /**
-     * The current time.
-     *
-     * @member {number}
-     * @default 0
-     */
+         * The current time.
+         *
+         * @member {number}
+         * @default 0
+         */
         this.time = options.time;
     }
 
     /**
-   * Applies the filter.
-   * @private
-   * @param {PIXI.FilterManager} filterManager - The manager.
-   * @param {PIXI.RenderTarget} input - The input target.
-   * @param {PIXI.RenderTarget} output - The output target.
-   */
+     * Applies the filter.
+     * @private
+     * @param {PIXI.FilterManager} filterManager - The manager.
+     * @param {PIXI.RenderTarget} input - The input target.
+     * @param {PIXI.RenderTarget} output - The output target.
+     */
     apply(filterManager, input, output, clear) {
-        const { width, height } = input.filterFrame;
+        const {width, height} = input.filterFrame;
 
         this.uniforms.light = this.parallel ? this._angleLight : this.center;
 
@@ -125,11 +120,11 @@ class GodrayFilter extends Filter {
     }
 
     /**
-   * The angle/light-source of the rays in degrees. For instance, a value of 0 is vertical rays,
-   *     values of 90 or -90 produce horizontal rays.
-   * @member {number}
-   * @default 30
-   */
+     * The angle/light-source of the rays in degrees. For instance, a value of 0 is vertical rays,
+     *     values of 90 or -90 produce horizontal rays.
+     * @member {number}
+     * @default 30
+     */
     get angle() {
         return this._angle;
     }
@@ -143,12 +138,12 @@ class GodrayFilter extends Filter {
     }
 
     /**
-   * General intensity of the effect. A value closer to 1 will produce a more intense effect,
-   * where a value closer to 0 will produce a subtler effect.
-   *
-   * @member {number}
-   * @default 0.5
-   */
+     * General intensity of the effect. A value closer to 1 will produce a more intense effect,
+     * where a value closer to 0 will produce a subtler effect.
+     *
+     * @member {number}
+     * @default 0.5
+     */
     get gain() {
         return this.uniforms.gain;
     }
@@ -157,12 +152,12 @@ class GodrayFilter extends Filter {
     }
 
     /**
-   * The density of the fractal noise. A higher amount produces more rays and a smaller amound
-   * produces fewer waves.
-   *
-   * @member {number}
-   * @default 2.5
-   */
+     * The density of the fractal noise. A higher amount produces more rays and a smaller amound
+     * produces fewer waves.
+     *
+     * @member {number}
+     * @default 2.5
+     */
     get lacunarity() {
         return this.uniforms.lacunarity;
     }
@@ -171,10 +166,10 @@ class GodrayFilter extends Filter {
     }
 
     /**
-   * The alpha of the filter
-   * @member {number}
-   * @default 1
-   */
+     * The alpha (opacity) of the rays.  0 is fully transparent, 1 is fully opaque
+     * @member {number}
+     * @default 1
+     */
     get alpha() {
         return this.uniforms.alpha;
     }

--- a/filters/godray/src/GodrayFilter.js
+++ b/filters/godray/src/GodrayFilter.js
@@ -1,8 +1,8 @@
-import {vertex} from '@tools/fragments';
-import perlin from './perlin.frag';
-import fragment from './gorday.frag';
-import {Filter} from '@pixi/core';
-import {Point, DEG_TO_RAD} from '@pixi/math';
+import { vertex } from "@tools/fragments";
+import perlin from "./perlin.frag";
+import fragment from "./gorday.frag";
+import { Filter } from "@pixi/core";
+import { Point, DEG_TO_RAD } from "@pixi/math";
 
 /**
  * GordayFilter, {@link https://codepen.io/alaingalvan originally} by Alain Galvan
@@ -26,138 +26,161 @@ import {Point, DEG_TO_RAD} from '@pixi/math';
  * @param {number} [options.time=0] The current time position.
  * @param {PIXI.Point|number[]} [options.center=[0,0]] Focal point for non-parallel rays,
  *        to use this `parallel` must be set to `false`.
+ * @param {number} [options.alpha=0.5] the alpha
  */
 class GodrayFilter extends Filter {
+  constructor(options) {
+    super(vertex, fragment.replace("${perlin}", perlin));
 
-    constructor(options) {
-        super(vertex, fragment.replace('${perlin}', perlin));
+    this.uniforms.dimensions = new Float32Array(2);
 
-        this.uniforms.dimensions = new Float32Array(2);
-
-        // Fallback support for ctor: (angle, gain, lacunarity, time)
-        if (typeof options === 'number') {
-            // eslint-disable-next-line no-console
-            console.warn('GodrayFilter now uses options instead of (angle, gain, lacunarity, time)');
-            options = { angle: options };
-            if (arguments[1] !== undefined) {
-                options.gain = arguments[1];
-            }
-            if (arguments[2] !== undefined) {
-                options.lacunarity = arguments[2];
-            }
-            if (arguments[3] !== undefined) {
-                options.time = arguments[3];
-            }
-        }
-
-        options = Object.assign({
-            angle: 30,
-            gain: 0.5,
-            lacunarity: 2.5,
-            time: 0,
-            parallel: true,
-            center: [0, 0],
-        }, options);
-
-        this._angleLight = new Point();
-        this.angle = options.angle;
-        this.gain = options.gain;
-        this.lacunarity = options.lacunarity;
-
-        /**
-         * `true` if light rays are parallel (uses angle),
-         * `false` to use the focal `center` point
-         *
-         * @member {boolean}
-         * @default true
-         */
-        this.parallel = options.parallel;
-
-        /**
-         * The position of the emitting point for light rays
-         * only used if `parallel` is set to `false`.
-         *
-         * @member {PIXI.Point|number[]}
-         * @default [0, 0]
-         */
-        this.center = options.center;
-
-        /**
-         * The current time.
-         *
-         * @member {number}
-         * @default 0
-         */
-        this.time = options.time;
+    // Fallback support for ctor: (angle, gain, lacunarity, time)
+    if (typeof options === "number") {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "GodrayFilter now uses options instead of (angle, gain, lacunarity, time)"
+      );
+      options = { angle: options };
+      if (arguments[1] !== undefined) {
+        options.gain = arguments[1];
+      }
+      if (arguments[2] !== undefined) {
+        options.lacunarity = arguments[2];
+      }
+      if (arguments[3] !== undefined) {
+        options.time = arguments[3];
+      }
+      if (arguments[4] !== undefined) {
+        options.alpha = arguments[4];
+      }
     }
 
+    options = Object.assign(
+      {
+        angle: 30,
+        gain: 0.5,
+        lacunarity: 2.5,
+        time: 0,
+        parallel: true,
+        center: [0, 0],
+        alpha: 0.0,
+      },
+      options
+    );
+
+    this._angleLight = new Point();
+    this.angle = options.angle;
+    this.gain = options.gain;
+    this.lacunarity = options.lacunarity;
+    this.alpha = options.alpha;
+
     /**
-     * Applies the filter.
-     * @private
-     * @param {PIXI.FilterManager} filterManager - The manager.
-     * @param {PIXI.RenderTarget} input - The input target.
-     * @param {PIXI.RenderTarget} output - The output target.
+     * `true` if light rays are parallel (uses angle),
+     * `false` to use the focal `center` point
+     *
+     * @member {boolean}
+     * @default true
      */
-    apply(filterManager, input, output, clear) {
-        const {width, height} = input.filterFrame;
-
-        this.uniforms.light = this.parallel ? this._angleLight : this.center;
-
-        this.uniforms.parallel = this.parallel;
-        this.uniforms.dimensions[0] = width;
-        this.uniforms.dimensions[1] = height;
-        this.uniforms.aspect = height / width;
-        this.uniforms.time = this.time;
-
-        // draw the filter...
-        filterManager.applyFilter(this, input, output, clear);
-    }
+    this.parallel = options.parallel;
 
     /**
-     * The angle/light-source of the rays in degrees. For instance, a value of 0 is vertical rays,
-     *     values of 90 or -90 produce horizontal rays.
-     * @member {number}
-     * @default 30
+     * The position of the emitting point for light rays
+     * only used if `parallel` is set to `false`.
+     *
+     * @member {PIXI.Point|number[]}
+     * @default [0, 0]
      */
-    get angle() {
-        return this._angle;
-    }
-    set angle(value) {
-        this._angle = value;
-
-        const radians = value * DEG_TO_RAD;
-
-        this._angleLight.x = Math.cos(radians);
-        this._angleLight.y = Math.sin(radians);
-    }
+    this.center = options.center;
 
     /**
-     * General intensity of the effect. A value closer to 1 will produce a more intense effect,
-     * where a value closer to 0 will produce a subtler effect.
+     * The current time.
      *
      * @member {number}
-     * @default 0.5
+     * @default 0
      */
-    get gain() {
-        return this.uniforms.gain;
-    }
-    set gain(value) {
-        this.uniforms.gain = value;
-    }
+    this.time = options.time;
+  }
 
-    /**
-     * The density of the fractal noise. A higher amount produces more rays and a smaller amound
-     * produces fewer waves.
-     *
-     * @member {number}
-     * @default 2.5
-     */
-    get lacunarity() {
-        return this.uniforms.lacunarity;
-    }
-    set lacunarity(value) {
-        this.uniforms.lacunarity = value;
-    }
+  /**
+   * Applies the filter.
+   * @private
+   * @param {PIXI.FilterManager} filterManager - The manager.
+   * @param {PIXI.RenderTarget} input - The input target.
+   * @param {PIXI.RenderTarget} output - The output target.
+   */
+  apply(filterManager, input, output, clear) {
+    const { width, height } = input.filterFrame;
+
+    this.uniforms.light = this.parallel ? this._angleLight : this.center;
+
+    this.uniforms.parallel = this.parallel;
+    this.uniforms.dimensions[0] = width;
+    this.uniforms.dimensions[1] = height;
+    this.uniforms.aspect = height / width;
+    this.uniforms.time = this.time;
+    this.uniforms.alpha = this.alpha;
+
+    // draw the filter...
+    filterManager.applyFilter(this, input, output, clear);
+  }
+
+  /**
+   * The angle/light-source of the rays in degrees. For instance, a value of 0 is vertical rays,
+   *     values of 90 or -90 produce horizontal rays.
+   * @member {number}
+   * @default 30
+   */
+  get angle() {
+    return this._angle;
+  }
+  set angle(value) {
+    this._angle = value;
+
+    const radians = value * DEG_TO_RAD;
+
+    this._angleLight.x = Math.cos(radians);
+    this._angleLight.y = Math.sin(radians);
+  }
+
+  /**
+   * General intensity of the effect. A value closer to 1 will produce a more intense effect,
+   * where a value closer to 0 will produce a subtler effect.
+   *
+   * @member {number}
+   * @default 0.5
+   */
+  get gain() {
+    return this.uniforms.gain;
+  }
+  set gain(value) {
+    this.uniforms.gain = value;
+  }
+
+  /**
+   * The density of the fractal noise. A higher amount produces more rays and a smaller amound
+   * produces fewer waves.
+   *
+   * @member {number}
+   * @default 2.5
+   */
+  get lacunarity() {
+    return this.uniforms.lacunarity;
+  }
+  set lacunarity(value) {
+    this.uniforms.lacunarity = value;
+  }
+
+  /**
+   * The alpha of the filter
+   * @member {number}
+   * @default 1
+   */
+  get alpha() {
+    return this.uniforms.alpha;
+  }
+  set alpha(value) {
+    this.uniforms.alpha = value;
+  }
 }
 
 export { GodrayFilter };

--- a/filters/godray/src/GodrayFilter.js
+++ b/filters/godray/src/GodrayFilter.js
@@ -1,8 +1,8 @@
-import { vertex } from "@tools/fragments";
-import perlin from "./perlin.frag";
-import fragment from "./gorday.frag";
-import { Filter } from "@pixi/core";
-import { Point, DEG_TO_RAD } from "@pixi/math";
+import { vertex } from '@tools/fragments';
+import perlin from './perlin.frag';
+import fragment from './gorday.frag';
+import { Filter } from '@pixi/core';
+import { Point, DEG_TO_RAD } from '@pixi/math';
 
 /**
  * GordayFilter, {@link https://codepen.io/alaingalvan originally} by Alain Galvan
@@ -29,158 +29,158 @@ import { Point, DEG_TO_RAD } from "@pixi/math";
  * @param {number} [options.alpha=0.5] the alpha
  */
 class GodrayFilter extends Filter {
-  constructor(options) {
-    super(vertex, fragment.replace("${perlin}", perlin));
+    constructor(options) {
+        super(vertex, fragment.replace('${perlin}', perlin));
 
-    this.uniforms.dimensions = new Float32Array(2);
+        this.uniforms.dimensions = new Float32Array(2);
 
-    // Fallback support for ctor: (angle, gain, lacunarity, time)
-    if (typeof options === "number") {
-      // eslint-disable-next-line no-console
-      console.warn(
-        "GodrayFilter now uses options instead of (angle, gain, lacunarity, time)"
-      );
-      options = { angle: options };
-      if (arguments[1] !== undefined) {
-        options.gain = arguments[1];
-      }
-      if (arguments[2] !== undefined) {
-        options.lacunarity = arguments[2];
-      }
-      if (arguments[3] !== undefined) {
-        options.time = arguments[3];
-      }
-      if (arguments[4] !== undefined) {
-        options.alpha = arguments[4];
-      }
-    }
+        // Fallback support for ctor: (angle, gain, lacunarity, time)
+        if (typeof options === 'number') {
+            // eslint-disable-next-line no-console
+            console.warn(
+                'GodrayFilter now uses options instead of (angle, gain, lacunarity, time)'
+            );
+            options = { angle: options };
+            if (arguments[1] !== undefined) {
+                options.gain = arguments[1];
+            }
+            if (arguments[2] !== undefined) {
+                options.lacunarity = arguments[2];
+            }
+            if (arguments[3] !== undefined) {
+                options.time = arguments[3];
+            }
+            if (arguments[4] !== undefined) {
+                options.alpha = arguments[4];
+            }
+        }
 
-    options = Object.assign(
-      {
-        angle: 30,
-        gain: 0.5,
-        lacunarity: 2.5,
-        time: 0,
-        parallel: true,
-        center: [0, 0],
-        alpha: 0.0,
-      },
-      options
-    );
+        options = Object.assign(
+            {
+                angle: 30,
+                gain: 0.5,
+                lacunarity: 2.5,
+                time: 0,
+                parallel: true,
+                center: [0, 0],
+                alpha: 0.0,
+            },
+            options
+        );
 
-    this._angleLight = new Point();
-    this.angle = options.angle;
-    this.gain = options.gain;
-    this.lacunarity = options.lacunarity;
-    this.alpha = options.alpha;
+        this._angleLight = new Point();
+        this.angle = options.angle;
+        this.gain = options.gain;
+        this.lacunarity = options.lacunarity;
+        this.alpha = options.alpha;
 
-    /**
+        /**
      * `true` if light rays are parallel (uses angle),
      * `false` to use the focal `center` point
      *
      * @member {boolean}
      * @default true
      */
-    this.parallel = options.parallel;
+        this.parallel = options.parallel;
 
-    /**
+        /**
      * The position of the emitting point for light rays
      * only used if `parallel` is set to `false`.
      *
      * @member {PIXI.Point|number[]}
      * @default [0, 0]
      */
-    this.center = options.center;
+        this.center = options.center;
 
-    /**
+        /**
      * The current time.
      *
      * @member {number}
      * @default 0
      */
-    this.time = options.time;
-  }
+        this.time = options.time;
+    }
 
-  /**
+    /**
    * Applies the filter.
    * @private
    * @param {PIXI.FilterManager} filterManager - The manager.
    * @param {PIXI.RenderTarget} input - The input target.
    * @param {PIXI.RenderTarget} output - The output target.
    */
-  apply(filterManager, input, output, clear) {
-    const { width, height } = input.filterFrame;
+    apply(filterManager, input, output, clear) {
+        const { width, height } = input.filterFrame;
 
-    this.uniforms.light = this.parallel ? this._angleLight : this.center;
+        this.uniforms.light = this.parallel ? this._angleLight : this.center;
 
-    this.uniforms.parallel = this.parallel;
-    this.uniforms.dimensions[0] = width;
-    this.uniforms.dimensions[1] = height;
-    this.uniforms.aspect = height / width;
-    this.uniforms.time = this.time;
-    this.uniforms.alpha = this.alpha;
+        this.uniforms.parallel = this.parallel;
+        this.uniforms.dimensions[0] = width;
+        this.uniforms.dimensions[1] = height;
+        this.uniforms.aspect = height / width;
+        this.uniforms.time = this.time;
+        this.uniforms.alpha = this.alpha;
 
-    // draw the filter...
-    filterManager.applyFilter(this, input, output, clear);
-  }
+        // draw the filter...
+        filterManager.applyFilter(this, input, output, clear);
+    }
 
-  /**
+    /**
    * The angle/light-source of the rays in degrees. For instance, a value of 0 is vertical rays,
    *     values of 90 or -90 produce horizontal rays.
    * @member {number}
    * @default 30
    */
-  get angle() {
-    return this._angle;
-  }
-  set angle(value) {
-    this._angle = value;
+    get angle() {
+        return this._angle;
+    }
+    set angle(value) {
+        this._angle = value;
 
-    const radians = value * DEG_TO_RAD;
+        const radians = value * DEG_TO_RAD;
 
-    this._angleLight.x = Math.cos(radians);
-    this._angleLight.y = Math.sin(radians);
-  }
+        this._angleLight.x = Math.cos(radians);
+        this._angleLight.y = Math.sin(radians);
+    }
 
-  /**
+    /**
    * General intensity of the effect. A value closer to 1 will produce a more intense effect,
    * where a value closer to 0 will produce a subtler effect.
    *
    * @member {number}
    * @default 0.5
    */
-  get gain() {
-    return this.uniforms.gain;
-  }
-  set gain(value) {
-    this.uniforms.gain = value;
-  }
+    get gain() {
+        return this.uniforms.gain;
+    }
+    set gain(value) {
+        this.uniforms.gain = value;
+    }
 
-  /**
+    /**
    * The density of the fractal noise. A higher amount produces more rays and a smaller amound
    * produces fewer waves.
    *
    * @member {number}
    * @default 2.5
    */
-  get lacunarity() {
-    return this.uniforms.lacunarity;
-  }
-  set lacunarity(value) {
-    this.uniforms.lacunarity = value;
-  }
+    get lacunarity() {
+        return this.uniforms.lacunarity;
+    }
+    set lacunarity(value) {
+        this.uniforms.lacunarity = value;
+    }
 
-  /**
+    /**
    * The alpha of the filter
    * @member {number}
    * @default 1
    */
-  get alpha() {
-    return this.uniforms.alpha;
-  }
-  set alpha(value) {
-    this.uniforms.alpha = value;
-  }
+    get alpha() {
+        return this.uniforms.alpha;
+    }
+    set alpha(value) {
+        this.uniforms.alpha = value;
+    }
 }
 
 export { GodrayFilter };

--- a/filters/godray/src/gorday.frag
+++ b/filters/godray/src/gorday.frag
@@ -26,7 +26,7 @@ void main(void) {
     } else {
         float dx = coord.x - light.x / dimensions.x;
         float dy = (coord.y - light.y / dimensions.y) * aspect;
-        float dis = sqrt(dx * dx + dy * dy) + .00001;
+        float dis = sqrt(dx * dx + dy * dy) + 0.00001;
         d = dy / dis;
     }
 

--- a/filters/godray/src/gorday.frag
+++ b/filters/godray/src/gorday.frag
@@ -32,7 +32,7 @@ void main(void) {
 
     vec3 dir = vec3(d, d, 0.0);
 
-    float noise = turb(dir + vec3(time, 0.0, 62.1 + time) * .05, vec3(480.0, 320.0, 480.0), lacunarity, gain);
+    float noise = turb(dir + vec3(time, 0.0, 62.1 + time) * 0.05, vec3(480.0, 320.0, 480.0), lacunarity, gain);
     noise = mix(noise, 0.0, 0.3);
     //fade vertically.
     vec4 mist = vec4(noise, noise, noise, 1.0) * (1.0 - coord.y);

--- a/filters/godray/src/gorday.frag
+++ b/filters/godray/src/gorday.frag
@@ -10,32 +10,35 @@ uniform float aspect;
 uniform float gain;
 uniform float lacunarity;
 uniform float time;
+uniform float alpha;
 
 ${perlin}
 
-void main(void) {
-    vec2 coord = vTextureCoord * filterArea.xy / dimensions.xy;
-
+void main(void){
+    vec2 coord=vTextureCoord*filterArea.xy/dimensions.xy;
+    
     float d;
-
-    if (parallel) {
-        float _cos = light.x;
-        float _sin = light.y;
-        d = (_cos * coord.x) + (_sin * coord.y * aspect);
-    } else {
-        float dx = coord.x - light.x / dimensions.x;
-        float dy = (coord.y - light.y / dimensions.y) * aspect;
-        float dis = sqrt(dx * dx + dy * dy) + 0.00001;
-        d = dy / dis;
+    
+    if(parallel){
+        float _cos=light.x;
+        float _sin=light.y;
+        d=(_cos*coord.x)+(_sin*coord.y*aspect);
+    }else{
+        float dx=coord.x-light.x/dimensions.x;
+        float dy=(coord.y-light.y/dimensions.y)*aspect;
+        float dis=sqrt(dx*dx+dy*dy)+.00001;
+        d=dy/dis;
     }
-
-    vec3 dir = vec3(d, d, 0.0);
-
-    float noise = turb(dir + vec3(time, 0.0, 62.1 + time) * 0.05, vec3(480.0, 320.0, 480.0), lacunarity, gain);
-    noise = mix(noise, 0.0, 0.3);
+    
+    vec3 dir=vec3(d,d,0.);
+    
+    float noise=turb(dir+vec3(time,0.,62.1+time)*.05,vec3(480.,320.,480.),lacunarity,gain);
+    noise=mix(noise,0.,.3);
     //fade vertically.
-    vec4 mist = vec4(noise, noise, noise, 1.0) * (1.0 - coord.y);
-    mist.a = 1.0;
-
-    gl_FragColor = texture2D(uSampler, vTextureCoord) + mist;
+    vec4 mist=vec4(noise,noise,noise,1.)*(1.-coord.y);
+    mist.a=1.;
+    mist*=alpha;
+    
+    gl_FragColor=texture2D(uSampler,vTextureCoord)+mist;
+    
 }

--- a/filters/godray/src/gorday.frag
+++ b/filters/godray/src/gorday.frag
@@ -14,31 +14,32 @@ uniform float alpha;
 
 ${perlin}
 
-void main(void){
-    vec2 coord=vTextureCoord*filterArea.xy/dimensions.xy;
-    
+void main(void) {
+    vec2 coord = vTextureCoord * filterArea.xy / dimensions.xy;
+
     float d;
-    
-    if(parallel){
-        float _cos=light.x;
-        float _sin=light.y;
-        d=(_cos*coord.x)+(_sin*coord.y*aspect);
-    }else{
-        float dx=coord.x-light.x/dimensions.x;
-        float dy=(coord.y-light.y/dimensions.y)*aspect;
-        float dis=sqrt(dx*dx+dy*dy)+.00001;
-        d=dy/dis;
+
+    if (parallel) {
+        float _cos = light.x;
+        float _sin = light.y;
+        d = (_cos * coord.x) + (_sin * coord.y * aspect);
+    } else {
+        float dx = coord.x - light.x / dimensions.x;
+        float dy = (coord.y - light.y / dimensions.y) * aspect;
+        float dis = sqrt(dx * dx + dy * dy) + .00001;
+        d = dy / dis;
     }
-    
-    vec3 dir=vec3(d,d,0.);
-    
-    float noise=turb(dir+vec3(time,0.,62.1+time)*.05,vec3(480.,320.,480.),lacunarity,gain);
-    noise=mix(noise,0.,.3);
+
+    vec3 dir = vec3(d, d, 0.0);
+
+    float noise = turb(dir + vec3(time, 0.0, 62.1 + time) * .05, vec3(480.0, 320.0, 480.0), lacunarity, gain);
+    noise = mix(noise, 0.0, 0.3);
     //fade vertically.
-    vec4 mist=vec4(noise,noise,noise,1.)*(1.-coord.y);
-    mist.a=1.;
-    mist*=alpha;
-    
-    gl_FragColor=texture2D(uSampler,vTextureCoord)+mist;
-    
+    vec4 mist = vec4(noise, noise, noise, 1.0) * (1.0 - coord.y);
+    mist.a = 1.0;
+    // apply user alpha
+    mist *= alpha;
+
+    gl_FragColor = texture2D(uSampler, vTextureCoord) + mist;
+
 }

--- a/filters/godray/types.d.ts
+++ b/filters/godray/types.d.ts
@@ -1,7 +1,6 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
     export class GodrayFilter extends PIXI.Filter {
-<<<<<<< HEAD
         constructor(options?:GodrayFilterOptions);
         angle:number;
         center:PIXI.Point|Array<number>;
@@ -19,25 +18,6 @@ declare namespace PIXI.filters {
         lacunarity:number;
         time:number;
         alpha:number;
-=======
-        constructor(options?: GodrayFilterOptions);
-        angle: number;
-        center: PIXI.Point | Array<number>;
-        parallel: boolean;
-        gain: number;
-        lacunarity: number;
-        time: number;
-        alpha: number;
-    }
-    export interface GodrayFilterOptions {
-        angle: number;
-        center: PIXI.Point | Array<number>;
-        parallel: boolean;
-        gain: number;
-        lacunarity: number;
-        time: number;
-        alpha: number;
->>>>>>> 550fd2bc1d343dcc6789cd3a62c51602b614368f
     }
 }
 

--- a/filters/godray/types.d.ts
+++ b/filters/godray/types.d.ts
@@ -1,27 +1,27 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-  export class GodrayFilter extends PIXI.Filter {
-    constructor(options?: GodrayFilterOptions);
-    angle: number;
-    center: PIXI.Point | Array<number>;
-    parallel: boolean;
-    gain: number;
-    lacunarity: number;
-    time: number;
-    alpha: number;
-  }
-  export interface GodrayFilterOptions {
-    angle: number;
-    center: PIXI.Point | Array<number>;
-    parallel: boolean;
-    gain: number;
-    lacunarity: number;
-    time: number;
-    alpha: number;
-  }
+    export class GodrayFilter extends PIXI.Filter {
+        constructor(options?:GodrayFilterOptions);
+        angle:number;
+        center:PIXI.Point|Array<number>;
+        parallel:boolean;
+        gain:number;
+        lacunarity:number;
+        time:number;
+        alpha:number;
+    }
+    export interface GodrayFilterOptions {
+        angle:number;
+        center:PIXI.Point|Array<number>;
+        parallel:boolean;
+        gain:number;
+        lacunarity:number;
+        time:number;
+        alpha:number;
+    }
 }
 
 declare module "@pixi/filter-godray" {
-  export import GodrayFilter = PIXI.filters.GodrayFilter;
-  export import GodrayFilterOptions = PIXI.filters.GodrayFilterOptions;
+    export import GodrayFilter = PIXI.filters.GodrayFilter;
+    export import GodrayFilterOptions = PIXI.filters.GodrayFilterOptions;
 }

--- a/filters/godray/types.d.ts
+++ b/filters/godray/types.d.ts
@@ -1,25 +1,27 @@
 /// <reference types="pixi.js" />
 declare namespace PIXI.filters {
-    export class GodrayFilter extends PIXI.Filter {
-        constructor(options?:GodrayFilterOptions);
-        angle:number;
-        center:PIXI.Point|Array<number>;
-        parallel:boolean;
-        gain:number;
-        lacunarity:number;
-        time:number;
-    }
-    export interface GodrayFilterOptions {
-        angle:number;
-        center:PIXI.Point|Array<number>;
-        parallel:boolean;
-        gain:number;
-        lacunarity:number;
-        time:number;
-    }
+  export class GodrayFilter extends PIXI.Filter {
+    constructor(options?: GodrayFilterOptions);
+    angle: number;
+    center: PIXI.Point | Array<number>;
+    parallel: boolean;
+    gain: number;
+    lacunarity: number;
+    time: number;
+    alpha: number;
+  }
+  export interface GodrayFilterOptions {
+    angle: number;
+    center: PIXI.Point | Array<number>;
+    parallel: boolean;
+    gain: number;
+    lacunarity: number;
+    time: number;
+    alpha: number;
+  }
 }
 
 declare module "@pixi/filter-godray" {
-    export import GodrayFilter = PIXI.filters.GodrayFilter;
-    export import GodrayFilterOptions = PIXI.filters.GodrayFilterOptions;
+  export import GodrayFilter = PIXI.filters.GodrayFilter;
+  export import GodrayFilterOptions = PIXI.filters.GodrayFilterOptions;
 }

--- a/filters/kawase-blur/src/KawaseBlurFilter.js
+++ b/filters/kawase-blur/src/KawaseBlurFilter.js
@@ -45,8 +45,8 @@ class KawaseBlurFilter extends Filter {
      * @private
      */
     apply(filterManager, input, output, clear) {
-        const uvX = this.pixelSize.x / input._frame.width;
-        const uvY = this.pixelSize.y / input._frame.height;
+        const uvX = this._pixelSize.x / input._frame.width;
+        const uvY = this._pixelSize.y / input._frame.height;
         let offset;
 
         if (this._quality === 1 || this._blur === 0) {

--- a/tools/demo/src/filters/godray.js
+++ b/tools/demo/src/filters/godray.js
@@ -8,6 +8,7 @@ export default function() {
         opened: false,
         oncreate: function(folder) {
 
+            this.alpha = 1;
             this.light = 30;
             this.gain = 0.6;
             this.lacunarity = 2.75;
@@ -30,6 +31,7 @@ export default function() {
             folder.add(this, 'time', 0, 1);
             folder.add(this, 'gain', 0, 1);
             folder.add(this, 'lacunarity', 0, 5);
+            folder.add(this, 'alpha', 0, 1);
             folder.add(this, 'parallel');
             folder.add(this, 'angle', -60, 60);
             folder.add(this.center, 'x', -100, app.initWidth + 100).name('center.x');


### PR DESCRIPTION
Addresses issue #262 

### Changelog
[add] Support for alpha including setter and getter to godray filter
[update] types accordingly
[update] tools/demo to include controls for `alpha`

Feel free to squash - I have an aggressive prettier config and had to fight it to get the formatting to match up better to avoid a noisy PR.

![image](https://user-images.githubusercontent.com/36850787/81424482-09f32000-9124-11ea-8df5-21e68e7de6ad.png)
