### PR TITLE
Add clear mode flag to x filter

### DIFF
--- a/filters/tilt-shift/src/TiltShiftFilter.js
+++ b/filters/tilt-shift/src/TiltShiftFilter.js
@@ -1,6 +1,7 @@
 import {TiltShiftXFilter} from './TiltShiftXFilter';
 import {TiltShiftYFilter} from './TiltShiftYFilter';
 import {Filter} from '@pixi/core';
+import {CLEAR_MODES} from '@pixi/constants';
 
 /**
  * @author Vico @vicocotea
@@ -31,7 +32,7 @@ class TiltShiftFilter extends Filter {
 
     apply(filterManager, input, output) {
         let renderTarget = filterManager.getFilterTexture();
-        this.tiltShiftXFilter.apply(filterManager, input, renderTarget);
+        this.tiltShiftXFilter.apply(filterManager, input, renderTarget, CLEAR_MODES.CLEAR);
         this.tiltShiftYFilter.apply(filterManager, renderTarget, output);
         filterManager.returnFilterTexture(renderTarget);
     }


### PR DESCRIPTION
I have only tested locally by sending a clear value of 1 (the value of CLEAR_MODES.CLEAR) to the x filter's apply(). I believe this pull includes the proper way of importing the constants from pixi but please check before accepting.