### PR TITLE
Support passing offset in TwistFilter constructor

### DIFF
--- a/filters/twist/package.json
+++ b/filters/twist/package.json
@@ -26,7 +26,8 @@
     "types.d.ts"
   ],
   "peerDependencies": {
-    "@pixi/core": "^5.0.0"
+    "@pixi/core": "^5.0.0",
+    "@pixi/math": "^5.0.0"
   },
   "devDependencies": {
     "@tools/fragments": "^3.0.3"

--- a/filters/twist/src/TwistFilter.js
+++ b/filters/twist/src/TwistFilter.js
@@ -1,6 +1,7 @@
 import {vertex} from '@tools/fragments';
 import fragment from './twist.frag';
 import {Filter} from '@pixi/core';
+import {Point} from '@pixi/math';
 
 /**
  * This filter applies a twist effect making display objects appear twisted in the given direction.<br>
@@ -11,17 +12,33 @@ import {Filter} from '@pixi/core';
  * @memberof PIXI.filters
  * @see {@link https://www.npmjs.com/package/@pixi/filter-twist|@pixi/filter-twist}
  * @see {@link https://www.npmjs.com/package/pixi-filters|pixi-filters}
- * @param {number} [radius=200] The radius of the twist.
- * @param {number} [angle=4] The angle of the twist.
- * @param {number} [padding=20] Padding for filter area.
+ * @param {object} [options] Object object to use.
+ * @param {number} [options.radius=200] The radius of the twist.
+ * @param {number} [options.angle=4] The angle of the twist.
+ * @param {number} [options.padding=20] Padding for filter area.
+ * @param {number} [options.offset] Center of twist, in local, pixel coordinates.
  */
 class TwistFilter extends Filter {
-    constructor(radius = 200, angle = 4, padding = 20) {
+    constructor(options) {
         super(vertex, fragment);
 
-        this.radius = radius;
-        this.angle = angle;
-        this.padding = padding;
+        // @deprecated: constructor (radius, angle, padding)
+        if (typeof options === 'number') {
+            options = { radius: options };
+            if (arguments[1] !== undefined) {
+                options.angle = arguments[1];
+            }
+            if (arguments[2] !== undefined) {
+                options.padding = arguments[2];
+            }
+        }
+
+        Object.assign(this, {
+            radius: 200,
+            angle: 4,
+            padding: 20,
+            offset: new Point(),
+        }, options);
     }
 
     /**

--- a/filters/twist/types.d.ts
+++ b/filters/twist/types.d.ts
@@ -1,7 +1,18 @@
 /// <reference types="pixi.js" />
+
 declare namespace PIXI.filters {
+    export interface TwistFilterOptions {
+        angle?: number;
+        offset?: PIXI.Point;
+        padding?: number;
+        radius?: number;
+    }
     export class TwistFilter extends PIXI.Filter {
-        constructor(radius?:number, angle?:number, padding?:number);
+        /**
+         * @deprecated Use options instead.
+         */
+        constructor(radius:number, angle?:number, padding?:number);
+        constructor(options?:TwistFilterOptions);
         angle:number;
         offset:PIXI.Point;
         radius:number;


### PR DESCRIPTION
This was annoying me and made this filter clunky to use. Related issue #244. The constructor options are because I wanted to include offset and the constructor arguments order didn't make sense in terms of importance.

* Supports passing `offset` as a constructor option
* Set's initial `offset` Point by default
* Deprecates the constructor spread `(radius, angle, padding)`
* Favors the use of constructor options
